### PR TITLE
Publish contextmenu jsTree event

### DIFF
--- a/struts2-jquery-tree-plugin/src/main/resources/template/js/struts2/jquery.tree.struts2.js
+++ b/struts2-jquery-tree-plugin/src/main/resources/template/js/struts2/jquery.tree.struts2.js
@@ -56,7 +56,42 @@
 			}
 			if (o.contextmenu) {
 				o.plugins.push("crrm"); 
-				o.plugins.push("contextmenu"); 
+				o.plugins.push("contextmenu");
+
+                $elem.on('delete_node.jstree', function (event, data){
+                    var orginal = {};
+                    orginal.data = data;
+                    orginal.event = event;
+                    self.publishTopic($elem, "delete_node", orginal);
+                });
+
+                $elem.on('create_node.jstree', function (event, data){
+                    var orginal = {};
+                    orginal.data = data;
+                    orginal.event = event;
+                    self.publishTopic($elem, "create_node", orginal);
+                });
+
+                $elem.on('rename_node.jstree', function (event, data){
+                    var orginal = {};
+                    orginal.data = data;
+                    orginal.event = event;
+                    self.publishTopic($elem, "rename_node", orginal);
+                });
+
+                $elem.on('move_node.jstree', function (event, data){
+                    var orginal = {};
+                    orginal.data = data;
+                    orginal.event = event;
+                    self.publishTopic($elem, "move_node", orginal);
+                });
+
+                $elem.on('copy_node.jstree', function (event, data){
+                    var orginal = {};
+                    orginal.data = data;
+                    orginal.event = event;
+                    self.publishTopic($elem, "copy_node", orginal);
+                });
 			}
 			if (o.types) {
 				o.plugins.push("types"); 


### PR DESCRIPTION
jsTree have built in JavaScript functionality for contextmenu delete create rename copy... but it can`t be used with struts2 plugin - I do not have new name for Create.
Now published jsTree events can be handled and updated on server side.