### PR TITLE
Fixes #46 and #36- sj:autocompleter does not properly handle cssErrorClass + add onErrorTopics support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,22 @@
-language: java
-jdk:
-  - oraclejdk8
-jobs: 
-  include:
-    - script:
-      - "mvn -DskipMinify=true --projects struts2-jquery-integration-tests -Dmaven.javadoc.skip=true verify"
-      - "mvn -DskipMinify=true --projects struts2-jquery-integration-tests -Dmaven.javadoc.skip=true -P phantomjs verify"
+{
+  "language": "java",
+  "jdk": "oraclejdk8",
+  "jobs": {
+    "include": [
+      {
+        "script": [
+          "mvn -DskipMinify=true --projects struts2-jquery-integration-tests -Dmaven.javadoc.skip=true verify"
+        ]
+      },
+      {
+        "script": [
+          "mvn -DskipMinify=true --projects struts2-jquery-integration-tests -Dmaven.javadoc.skip=true -P phantomjs verify"
+        ]
+      }
+    ]
+  },
+  "group": "stable",
+  "dist": "precise",
+  "os": "linux"
+}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: java
 jdk:
   - oraclejdk8
-script: 
-  - "mvn -DskipMinify=true -Dmaven.javadoc.skip=true verify"
-  - "mvn -DskipMinify=true --projects struts2-jquery-integration-tests -Dmaven.javadoc.skip=true -P phantomjs verify"
+jobs: 
+  include:
+    - script:
+      - "mvn -DskipMinify=true --projects struts2-jquery-integration-tests -Dmaven.javadoc.skip=true verify"
+      - "mvn -DskipMinify=true --projects struts2-jquery-integration-tests -Dmaven.javadoc.skip=true -P phantomjs verify"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
     ]
   },
   "group": "stable",
-  "dist": "precise",
+  "dist": "trusty",
   "os": "linux"
 }
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A Plugin for the popular java web framework struts2 to provide ajax functionalit
 ### versions and compatibility
 | `struts2-jquery` version | `struts2` version               |
 |--------------------------|---------------------------------|
-| `4.0.2`                  | version >= `2.5`                |
+| `4.0.3`                  | version >= `2.5`                |
 | `3.7.1`                  | `2.3.16` <= version <= `2.3.31` |
 
 As a general rule of thumb, it's advised to upgrade to the latest version within the same major version range. This should avoid bugs and vulnerabilities that already got fixed in more recent versions.
@@ -41,32 +41,32 @@ Since version 1.8.3 the plugin is found in the central Maven repository. Just ad
     <dependency>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery-plugin</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3</version>
     </dependency>
     <dependency>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery-grid-plugin</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3</version>
     </dependency>
     <dependency>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery-datatables-plugin</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3</version>
     </dependency>
     <dependency>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery-richtext-plugin</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3</version>
     </dependency>
     <dependency>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery-tree-plugin</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3</version>
     </dependency>
     <dependency>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery-mobile-plugin</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3</version>
     </dependency>
     ...
 </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.7</version>
+				<version>3.0.2</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 				</configuration>
@@ -107,7 +107,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.7.0</version>
 				<configuration>
 					<forceJavacCompilerUse>true</forceJavacCompilerUse>
 					<source>1.7</source>
@@ -130,8 +130,9 @@
 			</plugin>
 			<plugin>
 				<!-- Attach javadoc jar to builds -->
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.1</version>
+				<version>3.0.0-M1</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 				</configuration>
@@ -148,7 +149,7 @@
 				<!-- Attach source jar to builds -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.0.1</version>
 				<executions>
 					<execution>
 						<id>attach-source</id>
@@ -176,7 +177,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.5</version>
+						<version>1.6</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
 	<properties>
 		<currentVersion>${project.version}</currentVersion>
-		<struts2.version>2.5.12</struts2.version>
+		<struts2.version>2.5.13</struts2.version>
 		<tlib.version>2.3</tlib.version>
 		<minify.version>1.7.4</minify.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
 	<properties>
 		<currentVersion>${project.version}</currentVersion>
-		<struts2.version>2.5.13</struts2.version>
+		<struts2.version>2.5.14.1</struts2.version>
 		<tlib.version>2.3</tlib.version>
 		<minify.version>1.7.4</minify.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
 	<properties>
 		<currentVersion>${project.version}</currentVersion>
-		<struts2.version>2.5.10.1</struts2.version>
+		<struts2.version>2.5.12</struts2.version>
 		<tlib.version>2.3</tlib.version>
 		<minify.version>1.7.4</minify.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.jgeppert.struts2.jquery</groupId>
 	<artifactId>struts2-jquery</artifactId>
-	<version>4.0.3-SNAPSHOT</version>
+	<version>4.0.3</version>
 	<name>Struts 2 jQuery Plugin Parent Module</name>
 	<packaging>pom</packaging>
 	<url>https://github.com/struts-community-plugins/struts2-jquery</url>

--- a/struts2-jquery-archetypes/pom.xml
+++ b/struts2-jquery-archetypes/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     <groupId>com.jgeppert.struts2.jquery</groupId>
     <artifactId>struts2-jquery-archetypes</artifactId>

--- a/struts2-jquery-archetypes/struts2-jquery-archetype-base/pom.xml
+++ b/struts2-jquery-archetypes/struts2-jquery-archetype-base/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery-archetypes</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/struts2-jquery-archetypes/struts2-jquery-archetype-mobile/pom.xml
+++ b/struts2-jquery-archetypes/struts2-jquery-archetype-mobile/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery-archetypes</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/struts2-jquery-archetypes/struts2-jquery-bootstrap-archetype-grid/pom.xml
+++ b/struts2-jquery-archetypes/struts2-jquery-bootstrap-archetype-grid/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery-archetypes</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/struts2-jquery-chart-plugin/pom.xml
+++ b/struts2-jquery-chart-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     <artifactId>struts2-jquery-chart-plugin</artifactId>
     <name>Struts 2 jQuery Chart Plugin</name>

--- a/struts2-jquery-datatables-plugin/pom.xml
+++ b/struts2-jquery-datatables-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     <artifactId>struts2-jquery-datatables-plugin</artifactId>
     <name>Struts 2 jQuery DataTables Plugin</name>

--- a/struts2-jquery-grid-plugin/pom.xml
+++ b/struts2-jquery-grid-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     <artifactId>struts2-jquery-grid-plugin</artifactId>
     <name>Struts 2 jQuery Grid Plugin</name>

--- a/struts2-jquery-grid-plugin/src/main/java/com/jgeppert/struts2/jquery/grid/components/Grid.java
+++ b/struts2-jquery-grid-plugin/src/main/java/com/jgeppert/struts2/jquery/grid/components/Grid.java
@@ -44,7 +44,7 @@ import com.opensymphony.xwork2.util.ValueStack;
  *
  * @author <a href="http://www.jgeppert.com">Johannes Geppert</a>
  */
-@StrutsTag(name = "grid", tldTagClass = "com.jgeppert.struts2.jquery.grid.views.jsp.ui.GridTag", description = "Render an grid from a JSON Result.")
+@StrutsTag(name = "grid", tldTagClass = "com.jgeppert.struts2.jquery.grid.views.jsp.ui.GridTag", description = "Render a grid from a JSON Result.")
 public class Grid extends AbstractContainer {
 
     public static final String JQUERYACTION = "grid";

--- a/struts2-jquery-grid-plugin/src/main/java/com/jgeppert/struts2/jquery/grid/components/Grid.java
+++ b/struts2-jquery-grid-plugin/src/main/java/com/jgeppert/struts2/jquery/grid/components/Grid.java
@@ -47,788 +47,788 @@ import com.opensymphony.xwork2.util.ValueStack;
 @StrutsTag(name = "grid", tldTagClass = "com.jgeppert.struts2.jquery.grid.views.jsp.ui.GridTag", description = "Render an grid from a JSON Result.")
 public class Grid extends AbstractContainer {
 
-	public static final String JQUERYACTION = "grid";
-	public static final String TEMPLATE = "grid";
-	public static final String TEMPLATE_CLOSE = "grid-close";
-	public static final String COMPONENT_NAME = Grid.class.getName();
-
-	private static final String PARAM_NAVIGATOR_EXTRA_BUTTONS = "navigatorExtraButtons";
-	private static final String PARAM_SUB_GRID = "subGrid";
-	private static final String PARAM_PARENT_GRID = "parentGrid";
-	private static final String PARAM_SUB_GRID_URL = "subGridUrl";
-	private static final String PARAM_SUB_GRID_WIDTH = "subGridWidth";
-	private static final String PARAM_WIDTH = "width";
-	private static final String PARAM_HEIGHT = "height";
-	private static final String PARAM_PAGER = "pager";
-	private static final String PARAM_PAGER_BUTTONS = "pagerButtons";
-	private static final String PARAM_PAGER_INPUT = "pagerInput";
-	private static final String PARAM_PAGER_POSITION = "pagerPosition";
-	private static final String PARAM_ROW_NUM = "rowNum";
-	private static final String PARAM_SORTNAME = "sortname";
-	private static final String PARAM_VIEWRECORDS = "viewrecords";
-	private static final String PARAM_AUTOWIDTH = "autowidth";
-	private static final String PARAM_GRIDVIEW = "gridview";
-	private static final String PARAM_SORTORDER = "sortorder";
-	private static final String PARAM_LOADONCE = "loadonce";
-	private static final String PARAM_MULTISELECT = "multiselect";
-	private static final String PARAM_MULTIBOXONLY = "multiboxonly";
-	private static final String PARAM_EDITURL = "editurl";
-	private static final String PARAM_EDITINLINE = "editinline";
-	private static final String PARAM_CAPTION = "caption";
-	private static final String PARAM_SHRINK_TO_FIT = "shrinkToFit";
-	private static final String PARAM_GRID_MODEL = "gridModel";
-	private static final String PARAM_SCROLL = "scroll";
-	private static final String PARAM_ROW_LIST = "rowList";
-	private static final String PARAM_NAVIGATOR = "navigator";
-	private static final String PARAM_NAVIGATOR_ADD_OPTIONS = "navigatorAddOptions";
-	private static final String PARAM_NAVIGATOR_EDIT_OPTIONS = "navigatorEditOptions";
-	private static final String PARAM_NAVIGATOR_DELETE_OPTIONS = "navigatorDeleteOptions";
-	private static final String PARAM_NAVIGATOR_VIEW_OPTIONS = "navigatorViewOptions";
-	private static final String PARAM_NAVIGATOR_SEARCH_OPTIONS = "navigatorSearchOptions";
-	private static final String PARAM_NAVIGATOR_ADD = "navigatorAdd";
-	private static final String PARAM_NAVIGATOR_DELETE = "navigatorDelete";
-	private static final String PARAM_NAVIGATOR_EDIT = "navigatorEdit";
-	private static final String PARAM_NAVIGATOR_REFRESH = "navigatorRefresh";
-	private static final String PARAM_NAVIGATOR_VIEW = "navigatorView";
-	private static final String PARAM_NAVIGATOR_SEARCH = "navigatorSearch";
-	private static final String PARAM_NAVIGATOR_INLINE_EDIT_BUTTONS = "navigatorInlineEditButtons";
-	private static final String PARAM_NAVIGATOR_CLONE_TO_TOP = "navigatorCloneToTop";
-	private static final String PARAM_CELLURL = "cellurl";
-	private static final String PARAM_MULTISELECT_WIDTH = "multiselectWidth";
-	private static final String PARAM_PAGE = "page";
-	private static final String PARAM_AUTOENCODE = "autoencode";
-	private static final String PARAM_CELL_EDIT = "cellEdit";
-	private static final String PARAM_FOOTERROW = "footerrow";
-	private static final String PARAM_HIDDENGRID = "hiddengrid";
-	private static final String PARAM_HIDEGRID = "hidegrid";
-	private static final String PARAM_HOVERROWS = "hoverrows";
-	private static final String PARAM_ROWNUMBERS = "rownumbers";
-	private static final String PARAM_SCROLLROWS = "scrollrows";
-	private static final String PARAM_FILTER = "filter";
-	private static final String PARAM_FILTER_OPTIONS = "filterOptions";
-	private static final String PARAM_USER_DATA_ON_FOOTER = "userDataOnFooter";
-	private static final String PARAM_ALT_CLASS = "altClass";
-	private static final String PARAM_ALT_ROWS = "altRows";
-	private static final String PARAM_PRM_NAMES = "prmNames";
-	private static final String PARAM_DIRECTION = "direction";
-	private static final String PARAM_RECORDPOS = "recordpos";
-	private static final String PARAM_ROW_TOTAL = "rowTotal";
-	private static final String PARAM_VIEWSORTCOLS = "viewsortcols";
-	private static final String PARAM_TOPPAGER = "toppager";
-	private static final String PARAM_ON_SELECT_ROW_TOPICS = "onSelectRowTopics";
-	private static final String PARAM_ON_SELECT_ALL_TOPICS = "onSelectAllTopics";
-	private static final String PARAM_ON_CELL_SELECT_TOPICS = "onCellSelectTopics";
-	private static final String PARAM_ON_PAGING_TOPICS = "onPagingTopics";
-	private static final String PARAM_ON_SORT_COL_TOPICS = "onSortColTopics";
-	private static final String PARAM_ON_GRID_COMPLETE_TOPICS = "onGridCompleteTopics";
-	private static final String PARAM_ON_EDIT_INLINE_AFTER_SAVE_TOPICS = "onEditInlineAfterSaveTopics";
-	private static final String PARAM_ON_EDIT_INLINE_BEFORE_TOPICS = "onEditInlineBeforeTopics";
-	private static final String PARAM_ON_EDIT_INLINE_ERROR_TOPICS = "onEditInlineErrorTopics";
-	private static final String PARAM_ON_EDIT_INLINE_SUCCESS_TOPICS = "onEditInlineSuccessTopics";
-	private static final String PARAM_ON_CELL_EDIT_ERROR_TOPICS = "onCellEditErrorTopics";
-	private static final String PARAM_ON_CELL_EDIT_SUCCESS_TOPICS = "onCellEditSuccessTopics";
-	private static final String PARAM_ON_SUB_GRID_ROW_EXPANDED = "onSubGridRowExpanded";
-	private static final String PARAM_ON_CLICK_GROUP_TOPICS = "onClickGroupTopics";
-	private static final String PARAM_ON_DBL_CLICK_ROW_TOPICS = "onDblClickRowTopics";
-	private static final String PARAM_ON_RIGHT_CLICK_ROW_TOPICS = "onRightClickRowTopics";
-	private static final String PARAM_RELOAD_TOPICS = "reloadTopics";
-	private static final String PARAM_CONNECT_WITH = "connectWith";
-	private static final String PARAM_GROUP_FIELD = "groupField";
-	private static final String PARAM_GROUP_COLUMN_SHOW = "groupColumnShow";
-	private static final String PARAM_GROUP_TEXT = "groupText";
-	private static final String PARAM_GROUP_ORDER = "groupOrder";
-	private static final String PARAM_GROUP_SUMMARY = "groupSummary";
-	private static final String PARAM_GROUP_SHOW_SUMMARY_ON_HIDE = "groupShowSummaryOnHide";
-	private static final String PARAM_GROUP_PLUS_ICON = "groupPlusIcon";
-	private static final String PARAM_GROUP_MINUS_ICON = "groupMinusIcon";
-	private static final String PARAM_GROUP_DATA_SORTED = "groupDataSorted";
-	private static final String PARAM_GROUP_COLLAPSE = "groupCollapse";
-	private static final String PARAM_SORTABLE_ROWS = "sortableRows";
-
-	private static final String ID_PREFIX_GRID = "grid_";
-
-	protected String width;
-	protected String height;
-	protected String pager;
-	protected String pagerButtons;
-	protected String pagerPosition;
-	protected String pagerInput;
-	protected String rowNum;
-	protected String sortname;
-	protected String viewrecords;
-	protected String gridview;
-	protected String autowidth;
-	protected String sortorder;
-	protected String loadonce;
-	protected String multiselect;
-	protected String multiboxonly;
-	protected String editurl;
-	protected String editinline;
-	protected String caption;
-	protected String shrinkToFit;
-	protected String gridModel;
-	protected String rowList;
-	protected String scroll;
-	protected String navigator;
-	protected String navigatorEditOptions;
-	protected String navigatorAddOptions;
-	protected String navigatorDeleteOptions;
-	protected String navigatorSearchOptions;
-	protected String navigatorViewOptions;
-	protected String navigatorAdd;
-	protected String navigatorDelete;
-	protected String navigatorEdit;
-	protected String navigatorRefresh;
-	protected String navigatorSearch;
-	protected String navigatorView;
-	protected String navigatorInlineEditButtons;
-	protected String navigatorExtraButtons;
-	protected String navigatorCloneToTop;
-	protected String autoencode;
-	protected String cellEdit;
-	protected String cellurl;
-	protected String footerrow;
-	protected String hiddengrid;
-	protected String hidegrid;
-	protected String hoverrows;
-	protected String rownumbers;
-	protected String multiselectWidth;
-	protected String page;
-	protected String scrollrows;
-	protected String filter;
-	protected String subGridWidth;
-	protected String subGridUrl;
-	protected String userDataOnFooter;
-	protected String filterOptions;
-	protected String altClass;
-	protected String altRows;
-	protected String prmNames;
-	protected String direction;
-	protected String recordpos;
-	protected String rowTotal;
-	protected String viewsortcols;
-	protected String toppager;
-
-	protected String onSelectRowTopics;
-	protected String onSelectAllTopics;
-	protected String onPagingTopics;
-	protected String onSortColTopics;
-	protected String onCellSelectTopics;
-	protected String onGridCompleteTopics;
-	protected String onEditInlineBeforeTopics;
-	protected String onEditInlineSuccessTopics;
-	protected String onEditInlineErrorTopics;
-	protected String onEditInlineAfterSaveTopics;
-	protected String onCellEditSuccessTopics;
-	protected String onCellEditErrorTopics;
-	protected String onSubGridRowExpanded;
-	protected String onClickGroupTopics;
-	protected String onDblClickRowTopics;
-	protected String onRightClickRowTopics;
-	protected String reloadTopics;
-	protected String connectWith;
-	protected String groupField;
-	protected String groupColumnShow;
-	protected String groupText;
-	protected String groupCollapse;
-	protected String groupOrder;
-	protected String groupSummary;
-	protected String groupDataSorted;
-	protected String groupShowSummaryOnHide;
-	protected String groupPlusIcon;
-	protected String groupMinusIcon;
-	protected String sortableRows;
-
-	public Grid(ValueStack stack, HttpServletRequest request, HttpServletResponse response) {
-		super(stack, request, response);
-	}
-
-	@Override
-	public String getDefaultOpenTemplate() {
-		return TEMPLATE;
-	}
-
-	@Override
-	protected String getDefaultTemplate() {
-		return TEMPLATE_CLOSE;
-	}
-
-	@Override
-	public void evaluateExtraParams() {
-		super.evaluateExtraParams();
-
-		addParameter(PARAM_JQUERY_ACTION, JQUERYACTION);
-
-		Component parentGrid = findAncestor(Grid.class);
-		if (parentGrid != null) {
-			addParameter(PARAM_SUB_GRID, true);
-			addParameter(PARAM_PARENT_GRID, findString(((Grid) parentGrid).getId()));
-			addParameterIfPresent(PARAM_SUB_GRID_URL, this.subGridUrl);
-			addParameterIfPresent(PARAM_SUB_GRID_WIDTH, this.subGridWidth);
-		}
-		addParameterIfPresent(PARAM_WIDTH, this.width);
-		addParameterIfPresent(PARAM_HEIGHT, this.height);
-		addParameterIfPresent(PARAM_PAGER, this.pager, Boolean.class);
-		addParameterIfPresent(PARAM_PAGER_BUTTONS, this.pagerButtons, Boolean.class);
-		addParameterIfPresent(PARAM_PAGER_INPUT, this.pagerInput, Boolean.class);
-		addParameterIfPresent(PARAM_PAGER_POSITION, this.pagerPosition);
-		addParameterIfPresent(PARAM_ROW_NUM, this.rowNum);
-		addParameterIfPresent(PARAM_SORTNAME, this.sortname);
-		addParameterIfPresent(PARAM_SORTORDER, this.sortorder);
-		addParameterIfPresent(PARAM_VIEWRECORDS, this.viewrecords, Boolean.class);
-		addParameterIfPresent(PARAM_AUTOWIDTH, this.autowidth, Boolean.class);
-		addParameterIfPresent(PARAM_GRIDVIEW, this.gridview, Boolean.class);
-		addParameterIfPresent(PARAM_LOADONCE, this.loadonce, Boolean.class);
-		addParameterIfPresent(PARAM_MULTISELECT, this.multiselect, Boolean.class);
-		addParameterIfPresent(PARAM_MULTIBOXONLY, this.multiboxonly, Boolean.class);
-		addParameterIfPresent(PARAM_EDITURL, this.editurl);
-		addParameterIfPresent(PARAM_EDITINLINE, this.editinline, Boolean.class);
-		addParameterIfPresent(PARAM_CAPTION, this.caption);
-		addParameterIfPresent(PARAM_SHRINK_TO_FIT, this.shrinkToFit, Boolean.class);
-		addParameterIfPresent(PARAM_GRID_MODEL, this.gridModel);
-		addParameterIfPresent(PARAM_SCROLL, this.scroll);
-		addParameterIfPresent(PARAM_ROW_LIST, this.rowList);
-		addParameterIfPresent(PARAM_NAVIGATOR, this.navigator, Boolean.class);
-		addParameterIfPresent(PARAM_NAVIGATOR_ADD_OPTIONS, this.navigatorAddOptions);
-		addParameterIfPresent(PARAM_NAVIGATOR_EDIT_OPTIONS, this.navigatorEditOptions);
-		addParameterIfPresent(PARAM_NAVIGATOR_DELETE_OPTIONS, this.navigatorDeleteOptions);
-		addParameterIfPresent(PARAM_NAVIGATOR_VIEW_OPTIONS, this.navigatorViewOptions);
-		addParameterIfPresent(PARAM_NAVIGATOR_SEARCH_OPTIONS, this.navigatorSearchOptions);
-		addParameterIfPresent(PARAM_NAVIGATOR_ADD, this.navigatorAdd, Boolean.class);
-		addParameterIfPresent(PARAM_NAVIGATOR_DELETE, this.navigatorDelete, Boolean.class);
-		addParameterIfPresent(PARAM_NAVIGATOR_EDIT, this.navigatorEdit, Boolean.class);
-		addParameterIfPresent(PARAM_NAVIGATOR_REFRESH, this.navigatorRefresh, Boolean.class);
-		addParameterIfPresent(PARAM_NAVIGATOR_VIEW, this.navigatorView, Boolean.class);
-		addParameterIfPresent(PARAM_NAVIGATOR_SEARCH, this.navigatorSearch, Boolean.class);
-		addParameterIfPresent(PARAM_NAVIGATOR_EXTRA_BUTTONS, this.navigatorExtraButtons);
-		addParameterIfPresent(PARAM_NAVIGATOR_INLINE_EDIT_BUTTONS, this.navigatorInlineEditButtons, Boolean.class);
-		addParameterIfPresent(PARAM_NAVIGATOR_CLONE_TO_TOP, this.navigatorCloneToTop, Boolean.class);
-		addParameterIfPresent(PARAM_CELLURL, this.cellurl);
-		addParameterIfPresent(PARAM_MULTISELECT_WIDTH, this.multiselectWidth);
-		addParameterIfPresent(PARAM_PAGE, this.page);
-		addParameterIfPresent(PARAM_AUTOENCODE, this.autoencode, Boolean.class);
-		addParameterIfPresent(PARAM_CELL_EDIT, this.cellEdit, Boolean.class);
-		addParameterIfPresent(PARAM_FOOTERROW, this.footerrow, Boolean.class);
-		addParameterIfPresent(PARAM_HIDDENGRID, this.hiddengrid, Boolean.class);
-		addParameterIfPresent(PARAM_HIDEGRID, this.hidegrid, Boolean.class);
-		addParameterIfPresent(PARAM_HOVERROWS, this.hoverrows, Boolean.class);
-		addParameterIfPresent(PARAM_ROWNUMBERS, this.rownumbers, Boolean.class);
-		addParameterIfPresent(PARAM_SCROLLROWS, this.scrollrows, Boolean.class);
-		addParameterIfPresent(PARAM_FILTER, this.filter, Boolean.class);
-		addParameterIfPresent(PARAM_FILTER_OPTIONS, this.filterOptions);
-		addParameterIfPresent(PARAM_USER_DATA_ON_FOOTER, this.userDataOnFooter, Boolean.class);
-		addParameterIfPresent(PARAM_ALT_CLASS, this.altClass);
-		addParameterIfPresent(PARAM_ALT_ROWS, this.altRows, Boolean.class);
-		addParameterIfPresent(PARAM_PRM_NAMES, this.prmNames);
-		addParameterIfPresent(PARAM_DIRECTION, this.direction);
-		addParameterIfPresent(PARAM_RECORDPOS, this.recordpos);
-		addParameterIfPresent(PARAM_ROW_TOTAL, this.rowTotal, Integer.class);
-		addParameterIfPresent(PARAM_VIEWSORTCOLS, this.viewsortcols);
-		addParameterIfPresent(PARAM_TOPPAGER, this.toppager, Boolean.class);
-		addParameterIfPresent(PARAM_ON_SELECT_ROW_TOPICS, this.onSelectRowTopics);
-		addParameterIfPresent(PARAM_ON_SELECT_ALL_TOPICS, this.onSelectAllTopics);
-		addParameterIfPresent(PARAM_ON_CELL_SELECT_TOPICS, this.onCellSelectTopics);
-		addParameterIfPresent(PARAM_ON_PAGING_TOPICS, this.onPagingTopics);
-		addParameterIfPresent(PARAM_ON_SORT_COL_TOPICS, this.onSortColTopics);
-		addParameterIfPresent(PARAM_ON_GRID_COMPLETE_TOPICS, this.onGridCompleteTopics);
-		addParameterIfPresent(PARAM_ON_EDIT_INLINE_AFTER_SAVE_TOPICS, this.onEditInlineAfterSaveTopics);
-		addParameterIfPresent(PARAM_ON_EDIT_INLINE_BEFORE_TOPICS, this.onEditInlineBeforeTopics);
-		addParameterIfPresent(PARAM_ON_EDIT_INLINE_ERROR_TOPICS, this.onEditInlineErrorTopics);
-		addParameterIfPresent(PARAM_ON_EDIT_INLINE_SUCCESS_TOPICS, this.onEditInlineSuccessTopics);
-		addParameterIfPresent(PARAM_ON_CELL_EDIT_ERROR_TOPICS, this.onCellEditErrorTopics);
-		addParameterIfPresent(PARAM_ON_CELL_EDIT_SUCCESS_TOPICS, this.onCellEditSuccessTopics);
-		addParameterIfPresent(PARAM_ON_SUB_GRID_ROW_EXPANDED, this.onSubGridRowExpanded);
-		addParameterIfPresent(PARAM_ON_CLICK_GROUP_TOPICS, this.onClickGroupTopics);
-		addParameterIfPresent(PARAM_ON_DBL_CLICK_ROW_TOPICS, this.onDblClickRowTopics);
-		addParameterIfPresent(PARAM_ON_RIGHT_CLICK_ROW_TOPICS, this.onRightClickRowTopics);
-		addParameterIfPresent(PARAM_RELOAD_TOPICS, this.reloadTopics);
-		addParameterIfPresent(PARAM_CONNECT_WITH, this.connectWith);
-		addParameterIfPresent(PARAM_GROUP_FIELD, this.groupField);
-		addParameterIfPresent(PARAM_GROUP_COLUMN_SHOW, this.groupColumnShow);
-		addParameterIfPresent(PARAM_GROUP_TEXT, this.groupText);
-		addParameterIfPresent(PARAM_GROUP_ORDER, this.groupOrder);
-		addParameterIfPresent(PARAM_GROUP_SUMMARY, this.groupSummary);
-		addParameterIfPresent(PARAM_GROUP_SHOW_SUMMARY_ON_HIDE, this.groupShowSummaryOnHide, Boolean.class);
-		addParameterIfPresent(PARAM_GROUP_PLUS_ICON, this.groupPlusIcon);
-		addParameterIfPresent(PARAM_GROUP_MINUS_ICON, this.groupMinusIcon);
-		addParameterIfPresent(PARAM_GROUP_DATA_SORTED, this.groupDataSorted, Boolean.class);
-		addParameterIfPresent(PARAM_GROUP_COLLAPSE, this.groupCollapse, Boolean.class);
-
-		if (sortableRows != null) {
-			String sortableValue = findString(sortableRows);
-			if (BooleanUtils.toBoolean(sortableValue)) {
-				addParameter(PARAM_SORTABLE_ROWS, Boolean.TRUE);
-			}
-		}
-		addGeneratedIdParam(ID_PREFIX_GRID);
-	}
-
-	@Override
-	@StrutsTagSkipInheritance
-	public void setTheme(String theme) {
-		super.setTheme(theme);
-	}
-
-	@Override
-	public String getTheme() {
-		return "jquery";
-	}
-
-	@StrutsTagAttribute(description = "If this option is not set, the width of the grid is a sum of the widths of the columns defined in the colModel (in pixels). If this option is set, the initial width of each column is set according to the value of shrinkToFit option.")
-	public void setWidth(String width) {
-		this.width = width;
-	}
-
-	@StrutsTagAttribute(description = "The height of the grid. Can be set as number e.g. 400. Default: auto")
-	public void setHeight(String height) {
-		this.height = height;
-	}
-
-	@StrutsTagAttribute(description = "Defines that we want to use a pager bar to navigate through the records. This must be a true or false.", defaultValue = "false", type = "Boolean")
-	public void setPager(String pager) {
-		this.pager = pager;
-	}
-
-	@StrutsTagAttribute(description = "Determines if the Pager buttons should be shown if pager is available. Also valid only if pager is set correctly. The buttons are placed in the pager bar.", defaultValue = "true", type = "Boolean")
-	public void setPagerButtons(String pagerButtons) {
-		this.pagerButtons = pagerButtons;
-	}
-
-	@StrutsTagAttribute(description = "Determines the position of the pager in the grid. By default the pager element when created is divided in 3 parts. Can be left, center, right", defaultValue = "center")
-	public void setPagerPosition(String pagerPosition) {
-		this.pagerPosition = pagerPosition;
-	}
-
-	@StrutsTagAttribute(description = "DDetermines if the input box, where the user can change the number of requested page, should be available. The input box appear in the pager bar.", defaultValue = "true", type = "Boolean")
-	public void setPagerInput(String pagerInput) {
-		this.pagerInput = pagerInput;
-	}
-
-	@StrutsTagAttribute(description = "Sets how many records we want to view in the grid. This parameter is passed to the url for use by the server routine retrieving the data. Note that if you set this parameter to 10 (i.e. retrieve 10 records) and your server return 15 then only 10 records will be loaded. Set this parameter to -1 (unlimited) to disable this checking. Default: 20")
-	public void setRowNum(String rowNum) {
-		this.rowNum = rowNum;
-	}
-
-	@StrutsTagAttribute(description = "The initial sorting name. This parameter is added to the url. If set and the index (name) match the name from colModel then to this column by default is added a image sorting icon, according to the parameter sortorder (below).")
-	public void setSortname(String sortname) {
-		this.sortname = sortname;
-	}
-
-	@StrutsTagAttribute(description = "Defines whether we want to display the number of total records from the query in the pager bar.", defaultValue = "false", type = "Boolean")
-	public void setViewrecords(String viewrecords) {
-		this.viewrecords = viewrecords;
-	}
-
-	@StrutsTagAttribute(description = "Insert the entry row at once with a jQuery append. The result is impressive - about 3-5 times faster. If set to true we can not use treeGrid, subGrid, or afterInsertRow event.", defaultValue = "false", type = "Boolean")
-	public void setGridview(String gridview) {
-		this.gridview = gridview;
-	}
-
-	@StrutsTagAttribute(description = "When set to true, the grid width is recalculated automatically to the width of the parent element. This is done only initially when the grid is created.", defaultValue = "false", type = "Boolean")
-	public void setAutowidth(String autowidth) {
-		this.autowidth = autowidth;
-	}
-
-	@StrutsTagAttribute(description = "The initial sorting order.This parameter is added to the url - see prnNames. Two possible values - asc or desc. Default asc")
-	public void setSortorder(String sortorder) {
-		this.sortorder = sortorder;
-	}
-
-	@StrutsTagAttribute(description = "If this flag is set to true, the grid loads the data from the server only once. After the first request all further manipulations are done on the client side. The functions of the pager (if present) are disabled.", defaultValue = "false", type = "Boolean")
-	public void setLoadonce(String loadonce) {
-		this.loadonce = loadonce;
-	}
-
-	@StrutsTagAttribute(description = "If this flag is set to true a multi selection of rows is enabled. A new column at left side is added.", defaultValue = "false", type = "Boolean")
-	public void setMultiselect(String multiselect) {
-		this.multiselect = multiselect;
-	}
-
-	@StrutsTagAttribute(description = "This option works only when multiselect = true. When multiselect is set to true, clicking anywhere on a row selects that row; when multiboxonly is also set to true, the multiselection is done only when the checkbox is clicked (Yahoo style). Clicking in any other row (suppose the checkbox is not clicked) deselects all rows and the current row is selected.", defaultValue = "false", type = "Boolean")
-	public void setMultiboxonly(String multiboxonly) {
-		this.multiboxonly = multiboxonly;
-	}
-
-	@StrutsTagAttribute(description = "Defines the url for inline and form editing.")
-	public void setEditurl(String editurl) {
-		this.editurl = editurl;
-	}
-
-	@StrutsTagAttribute(description = "Enable editing inline. Default: false", defaultValue = "false", type = "Boolean")
-	public void setEditinline(String editinline) {
-		this.editinline = editinline;
-	}
-
-	@StrutsTagAttribute(description = "Defines the Caption layer for the grid. This caption appear above the Header layer. If the string is empty the caption does not appear.")
-	public void setCaption(String caption) {
-		this.caption = caption;
-	}
-
-	@StrutsTagAttribute(description = "This option describes the type of calculation of the initial width of each column against with the width of the grid. If the value is true and the value in width option is set then: Every column width is scaled according to the defined option width.", defaultValue = "true", type = "Boolean")
-	public void setShrinkToFit(String shrinkToFit) {
-		this.shrinkToFit = shrinkToFit;
-	}
-
-	@StrutsTagAttribute(description = "Name of you grid model. Must be a Collection", required = true)
-	public void setGridModel(String gridModel) {
-		this.gridModel = gridModel;
-	}
-
-	@StrutsTagAttribute(description = "An array to construct a select box element in the pager in which we can change the number of the visible rows. e.g. 10,15,20")
-	public void setRowList(String rowList) {
-		this.rowList = rowList;
-	}
-
-	@StrutsTagAttribute(description = "Creates dynamic scrolling grids. When enabled, the pager elements are disabled and we can use the vertical scrollbar to load data. When set to true the grid will always hold all the items from the start through to the latest point ever visited.", defaultValue = "false")
-	public void setScroll(String scroll) {
-		this.scroll = scroll;
-	}
-
-	@StrutsTagAttribute(description = "Navigator is a method that can add predefined actions like editing, adding, deleting, and searching. This must be a true or false.", defaultValue = "false", type = "Boolean")
-	public void setNavigator(String navigator) {
-		this.navigator = navigator;
-	}
-
-	@StrutsTagAttribute(description = "Edit Options for Navigator. e.g. {height:280,reloadAfterSubmit:false},")
-	public void setNavigatorEditOptions(String navigatorEditOptions) {
-		this.navigatorEditOptions = navigatorEditOptions;
-	}
-
-	@StrutsTagAttribute(description = "Add Options for Navigator. e.g. {height:280,reloadAfterSubmit:false},")
-	public void setNavigatorAddOptions(String navigatorAddOptions) {
-		this.navigatorAddOptions = navigatorAddOptions;
-	}
-
-	@StrutsTagAttribute(description = "Delete Options for Navigator. e.g. {height:280,reloadAfterSubmit:false},")
-	public void setNavigatorDeleteOptions(String navigatorDeleteOptions) {
-		this.navigatorDeleteOptions = navigatorDeleteOptions;
-	}
-
-	@StrutsTagAttribute(description = "Search Options for Navigator. e.g. {height:280,reloadAfterSubmit:false},")
-	public void setNavigatorSearchOptions(String navigatorSearchOptions) {
-		this.navigatorSearchOptions = navigatorSearchOptions;
-	}
-
-	@StrutsTagAttribute(description = "View Options for Navigator. e.g. {sopt:['cn','bw','eq','ne','lt','gt','ew']},")
-	public void setNavigatorViewOptions(String navigatorViewOptions) {
-		this.navigatorViewOptions = navigatorViewOptions;
-	}
-
-	@StrutsTagAttribute(description = "Clones all the actions from the bottom pager to the top pager if defined.", defaultValue = "false", type = "Boolean")
-	public void setNavigatorCloneToTop(String navigatorCloneToTop) {
-		this.navigatorCloneToTop = navigatorCloneToTop;
-	}
-
-	@StrutsTagAttribute(description = "When set to true encodes (html encode) the incoming (from server) and posted data (from editing modules). By example < will be converted to &lt;", defaultValue = "true", type = "Boolean")
-	public void setAutoencode(String autoencode) {
-		this.autoencode = autoencode;
-	}
-
-	@StrutsTagAttribute(description = "Enables (disables) cell editing. See Cell Editing for more details", defaultValue = "false", type = "Boolean")
-	public void setCellEdit(String cellEdit) {
-		this.cellEdit = cellEdit;
-	}
-
-	@StrutsTagAttribute(description = "the url where the cell is to be saved.", defaultValue = "false", type = "Boolean")
-	public void setCellurl(String cellurl) {
-		this.cellurl = cellurl;
-	}
-
-	@StrutsTagAttribute(description = "If set to true this will place a footer table with one row below the gird records and above the pager.", defaultValue = "false", type = "Boolean")
-	public void setFooterrow(String footerrow) {
-		this.footerrow = footerrow;
-	}
-
-	@StrutsTagAttribute(description = "If set to true the grid initially is hidden. The data is not loaded (no request is sent) and only the caption layer is shown. When the show/hide button is clicked the first time to show grid, the request is sent to the server, the data is loaded, and grid is shown. From this point we have a regular grid.", defaultValue = "false", type = "Boolean")
-	public void setHiddengrid(String hiddengrid) {
-		this.hiddengrid = hiddengrid;
-	}
-
-	@StrutsTagAttribute(description = "Enables or disables the show/hide grid button, which appears on the right side of the Caption layer. Takes effect only if the caption property is not an empty string.", defaultValue = "false", type = "Boolean")
-	public void setHidegrid(String hidegrid) {
-		this.hidegrid = hidegrid;
-	}
-
-	@StrutsTagAttribute(description = "When set to false the mouse hovering is disabled in the grid data rows.", defaultValue = "false", type = "Boolean")
-	public void setHoverrows(String hoverrows) {
-		this.hoverrows = hoverrows;
-	}
-
-	@StrutsTagAttribute(description = "If this option is set to true, a new column at left of the grid is added. The purpose of this column is to count the number of available rows, beginning from 1. In this case colModel is extended automatically with new element with name - 'rn'. Also, be careful not to use the name 'rn' in gridModel", defaultValue = "false", type = "Boolean")
-	public void setRownumbers(String rownumbers) {
-		this.rownumbers = rownumbers;
-	}
-
-	@StrutsTagAttribute(description = "etermines the width of the multiselect column if multiselect is set to true.")
-	public void setMultiselectWidth(String multiselectWidth) {
-		this.multiselectWidth = multiselectWidth;
-	}
-
-	@StrutsTagAttribute(description = "Set the initial number of page when we make the request.This parameter is passed to the url for use by the server routine retrieving the data", defaultValue = "1")
-	public void setPage(String page) {
-		this.page = page;
-	}
-
-	@StrutsTagAttribute(description = "When enabled, selecting a row with setSelection scrolls the grid so that the selected row is visible.", defaultValue = "false", type = "Boolean")
-	public void setScrollrows(String scrollrows) {
-		this.scrollrows = scrollrows;
-	}
-
-	@StrutsTagAttribute(description = "Enables or disables the add action in the navigator. When the button is clicked a editGridRow with parameter new method is executed", defaultValue = "true", type = "Boolean")
-	public void setNavigatorAdd(String navigatorAdd) {
-		this.navigatorAdd = navigatorAdd;
-	}
-
-	@StrutsTagAttribute(description = "Enables or disables the delete action in the navigator. When the button is clicked a delGridRow method is executed.", defaultValue = "true", type = "Boolean")
-	public void setNavigatorDelete(String navigatorDelete) {
-		this.navigatorDelete = navigatorDelete;
-	}
-
-	@StrutsTagAttribute(description = "Enables or disables the edit action in the navigator. When the button is clicked a editGridRow method is executed with parameter the - current selected row", defaultValue = "true", type = "Boolean")
-	public void setNavigatorEdit(String navigatorEdit) {
-		this.navigatorEdit = navigatorEdit;
-	}
-
-	@StrutsTagAttribute(description = "Enables or disables the refresh button in the pager. When the button is clicked a trigger(reloadGrid) is executed and the search parameters are cleared", defaultValue = "true", type = "Boolean")
-	public void setNavigatorRefresh(String navigatorRefresh) {
-		this.navigatorRefresh = navigatorRefresh;
-	}
-
-	@StrutsTagAttribute(description = "Enables or disables the search button in the pager.When the button is clicked a searchGrid method is executed", defaultValue = "true", type = "Boolean")
-	public void setNavigatorSearch(String navigatorSearch) {
-		this.navigatorSearch = navigatorSearch;
-	}
-
-	@StrutsTagAttribute(description = "Enables or disables the view button in the pager. When the button is clicked a viewGridRow method is executed", defaultValue = "false", type = "Boolean")
-	public void setNavigatorView(String navigatorView) {
-		this.navigatorView = navigatorView;
-	}
-
-	@StrutsTagAttribute(description = "Add extra buttons to Navigator. e.g.: { seperator: { title : 'seperator'  }, hidebutton : { title : 'Show Hide', icon: 'ui-icon-gear', topic: showHideGrid} }")
-	public void setNavigatorExtraButtons(String navigatorExtraButtons) {
-		this.navigatorExtraButtons = navigatorExtraButtons;
-	}
-
-	@StrutsTagAttribute(description = "Show buttons for edit and add rows in case of editinline is true.", defaultValue = "true", type = "Boolean")
-	public void setNavigatorInlineEditButtons(String navigatorInlineEditButtons) {
-		this.navigatorInlineEditButtons = navigatorInlineEditButtons;
-	}
-
-	@StrutsTagAttribute(description = "This method construct searching creating input elements just below the header elements of the grid.", defaultValue = "false", type = "Boolean")
-	public void setFilter(String filter) {
-		this.filter = filter;
-	}
-
-	@StrutsTagAttribute(description = "Determines the width of the subGrid column if subgrid is enabled.")
-	public void setSubGridWidth(String subGridWidth) {
-		this.subGridWidth = subGridWidth;
-	}
-
-	@StrutsTagAttribute(description = "This option has effect only if subGrid option is set to true. This option points to the file from which we get the data for the subgrid. jqGrid adds the id of the row to this url as parameter.")
-	public void setSubGridUrl(String subGridUrl) {
-		this.subGridUrl = subGridUrl;
-	}
-
-	@StrutsTagAttribute(description = "When set to true we directly place the user data array userData at footer. The rules are as follow: If the userData array contain name which is equal to those of colModel then the value is placed in that column.If there are no such values nothing is palced. Note that if this option is used we use the current formatter options (if available) for that column.")
-	public void setUserDataOnFooter(String userDataOnFooter) {
-		this.userDataOnFooter = userDataOnFooter;
-	}
-
-	@StrutsTagAttribute(description = "Options for Filter Settings as JavaScript Object. e.g. { autosearch : false, formtype : vertical }")
-	public void setFilterOptions(String filterOptions) {
-		this.filterOptions = filterOptions;
-	}
-
-	@StrutsTagAttribute(description = "The class that is used for alternate rows. You can construct your own class and replace this value. This option is valid only if altRows options is set to true", defaultValue = "ui-priority-secondary")
-	public void setAltClass(String altClass) {
-		this.altClass = altClass;
-	}
-
-	@StrutsTagAttribute(description = "Set a zebra-striped grid", defaultValue = "false", type = "Boolean")
-	public void setAltRows(String altRows) {
-		this.altRows = altRows;
-	}
-
-	@StrutsTagAttribute(description = "Customizes names of the fields sent to the server on a Post. When some parameter is set to null they will be not sended to the server.", defaultValue = "{page:\"page\",rows:\"rows\", sort: \"sidx\",order: \"sord\", search:\"_search\", nd:\"nd\", id:\"id\",oper:\"oper\",editoper:\"edit\",addoper:\"add\",deloper:\"del\"}")
-	public void setPrmNames(String prmNames) {
-		this.prmNames = prmNames;
-	}
-
-	@StrutsTagAttribute(description = "Determines the language direction in grid. The default is 'ltr' (Left To Right language). When set to 'rtl' (Right To Left) the grid automatically do the needed.", defaultValue = "ltr")
-	public void setDirection(String direction) {
-		this.direction = direction;
-	}
-
-	@StrutsTagAttribute(description = "Determines the position of the record information in the pager. Can be left, center, right", defaultValue = "right")
-	public void setRecordpos(String recordpos) {
-		this.recordpos = recordpos;
-	}
-
-	@StrutsTagAttribute(description = "When set this parameter can instruct the server to load the total number of rows needed to work on. Note that rowNum determines the total records displayed in the grid, while rowTotal the total rows on which we operate. When this parameter is set we send a additional parameter to server named totalrows. You can check for this parameter and if it is available you can replace the rows parameter with this one. Mostly this parameter can be combined wit loadonce parameter set to true.", defaultValue = "null", type = "Integer")
-	public void setRowTotal(String rowTotal) {
-		this.rowTotal = rowTotal;
-	}
-
-	@StrutsTagAttribute(description = "The purpose of this parameter is to define different look and behavior of sorting icons that appear near the header. This parameter is array with the following default options viewsortcols : [false,'vertical',true]. The first parameter determines if all icons should be viewed at the same time when all columns have sort property set to true. The default of false determines that only the icons of the current sorting column should be viewed. Setting this parameter to true causes all icons in all sortable columns to be viewed. The second parameter determines how icons should be placed - vertical means that the sorting icons are one under another. 'horizontal' means that the icons should be one near other. The third parameter determines the click functionality. If set to true the columns are sorted if the header is clicked. If set to false the columns are sorted only when the icons are clicked. Important note: When set a third parameter to false be a sure that the first parameter is set to true, otherwise you will loose the sorting.", defaultValue = "false")
-	public void setViewsortcols(String viewsortcols) {
-		this.viewsortcols = viewsortcols;
-	}
-
-	@StrutsTagAttribute(description = "When enabled this option place a pager element at top of the grid below the caption (if available).", defaultValue = "false", type = "Boolean")
-	public void setToppager(String toppager) {
-		this.toppager = toppager;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published when a row is selected")
-	public void setOnSelectRowTopics(String onSelectRowTopics) {
-		this.onSelectRowTopics = onSelectRowTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published when multiselect option is true and you click on the header checkbox.")
-	public void setOnSelectAllTopics(String onSelectAllTopics) {
-		this.onSelectAllTopics = onSelectAllTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published after click on page button and before populating the data. Parameter: pgButton")
-	public void setOnPagingTopics(String onPagingTopics) {
-		this.onPagingTopics = onPagingTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published immediately after sortable column was clicked and before sorting the data. Parameters: index is the index name from colModel, iCol is the index of column, sortorder is the new sorting order - can be 'asc' or 'desc'")
-	public void setOnSortColTopics(String onSortColTopics) {
-		this.onSortColTopics = onSortColTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published when we click on particular cell in the grid. Parameters: rowid is the id of the row, iCol is the index of the cell, cellcontent is the content of the cell, e is the event object element where we click.")
-	public void setOnCellSelectTopics(String onCellSelectTopics) {
-		this.onCellSelectTopics = onCellSelectTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published after all the data is loaded into the grid and all other processes are complete.")
-	public void setOnGridCompleteTopics(String onGridCompleteTopics) {
-		this.onGridCompleteTopics = onGridCompleteTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published after successfully accessing the row for editing, prior to allowing user access to the input fields.")
-	public void setOnEditInlineBeforeTopics(String onEditInlineBeforeTopics) {
-		this.onEditInlineBeforeTopics = onEditInlineBeforeTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published is called immediately after the request is successful.")
-	public void setOnEditInlineSuccessTopics(String onEditInlineSuccessTopics) {
-		this.onEditInlineSuccessTopics = onEditInlineSuccessTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published is called immediately after the data is saved to the server")
-	public void setOnEditInlineErrorTopics(String onEditInlineErrorTopics) {
-		this.onEditInlineErrorTopics = onEditInlineErrorTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published is called immediately after the data is saved to the server")
-	public void setOnEditInlineAfterSaveTopics(String onEditInlineAfterSaveTopics) {
-		this.onEditInlineAfterSaveTopics = onEditInlineAfterSaveTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published is called immediately after the cell has been successfully saved.")
-	public void setOnCellEditSuccessTopics(String onCellEditSuccessTopics) {
-		this.onCellEditSuccessTopics = onCellEditSuccessTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published is called immediately if there is a server error.")
-	public void setOnCellEditErrorTopics(String onCellEditErrorTopics) {
-		this.onCellEditErrorTopics = onCellEditErrorTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published when subgrid row is expanded. Set event.originalEvent.orginal.proceed = false in your topic to prevent default action.")
-	public void setOnSubGridRowExpanded(String onSubGridRowExpanded) {
-		this.onSubGridRowExpanded = onSubGridRowExpanded;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published when a group is clicked.")
-	public void setOnClickGroupTopics(String onClickGroupTopics) {
-		this.onClickGroupTopics = onClickGroupTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published row was double clicked.")
-	public void setOnDblClickRowTopics(String onDblClickRowTopics) {
-		this.onDblClickRowTopics = onDblClickRowTopics;
-	}
-
-	@StrutsTagAttribute(description = "A comma delimited list of topics that published after row was right clicked. Note - this event does not work in Opera browsers, since Opera does not support oncontextmenu event")
-	public void setOnRightClickRowTopics(String onRightClickRowTopics) {
-		this.onRightClickRowTopics = onRightClickRowTopics;
-	}
-
-	@Override
-	@StrutsTagAttribute(name = "reloadTopics", description = "A comma delimited list of topics that will cause this grid to reload")
-	public void setReloadTopics(String reloadTopics) {
-		this.reloadTopics = reloadTopics;
-	}
-
-	@StrutsTagAttribute(description = "Determines the target grid(s) to which the row should be dropped. The option is a string. In case of more than one grid the ids should be delemited with comma - i.e #grid1, #grid2 ", defaultValue = "empty string")
-	public void setConnectWith(String connectWith) {
-		this.connectWith = connectWith;
-	}
-
-	@StrutsTagAttribute(description = "Defines the name from  colModel  on which we group. The first value is the first lavel, the second values is the second level and etc. Currently only one level is supported. e.g. ['name']")
-	public void setGroupField(String groupField) {
-		this.groupField = groupField;
-	}
-
-	@StrutsTagAttribute(description = "Show/Hide the column on which we group. The value here should be a boolean true/false for the group level. If the grouping is enabled we set this value to true. e.g. [true]")
-	public void setGroupColumnShow(String groupColumnShow) {
-		this.groupColumnShow = groupColumnShow;
-	}
-
-	@StrutsTagAttribute(description = "Defines the grouping header text for the group level that will be displayed in the grid. By default if defined the value if {0} which means that the group value name will be displayed. It is possible to specify another value {1} which meant the the total cont of this group will be displayed too. It is possible to set here any valid html content. e.g. ['<b>{0} - {1} Item(s)</b>'] ")
-	public void setGroupText(String groupText) {
-		this.groupText = groupText;
-	}
-
-	@StrutsTagAttribute(description = "Defines if the initially the grid should show or hide the detailed rows of the group.", defaultValue = "false", type = "Boolean")
-	public void setGroupCollapse(String groupCollapse) {
-		this.groupCollapse = groupCollapse;
-	}
-
-	@StrutsTagAttribute(description = "Defines the initial sort order of the group level. Can be asc for ascending or desc for descending order. If the grouping is enabled the default value is asc. e.g. ['asc']")
-	public void setGroupOrder(String groupOrder) {
-		this.groupOrder = groupOrder;
-	}
-
-	@StrutsTagAttribute(description = "Enable or disable the summary (footer) row of the current group level. If grouping is set the default value for the group is false. e.g. [true]")
-	public void setGroupSummary(String groupSummary) {
-		this.groupSummary = groupSummary;
-	}
-
-	@StrutsTagAttribute(description = "If this parameter is set to true we send a additional parameter to the server in order to tell him to sort the data. This way all the sorting is done at server leaving the grid only to display the grouped data. If this parameter is false additionally before to display the data we make our own sorting in order to support grouping. This of course slow down the speed on relative big data. This parameter is not valid is the datatype is local.", defaultValue = "false", type = "Boolean")
-	public void setGroupDataSorted(String groupDataSorted) {
-		this.groupDataSorted = groupDataSorted;
-	}
-
-	@StrutsTagAttribute(description = "Show or hide the summary (footer) row when we collapse the group.", defaultValue = "false", type = "Boolean")
-	public void setGroupShowSummaryOnHide(String groupShowSummaryOnHide) {
-		this.groupShowSummaryOnHide = groupShowSummaryOnHide;
-	}
-
-	@StrutsTagAttribute(description = "Set the icon from jQuery UI Theme Roller that will be used if the grouped row is collapsed", defaultValue = "ui-icon-circlesmall-plus")
-	public void setGroupPlusIcon(String groupPlusIcon) {
-		this.groupPlusIcon = groupPlusIcon;
-	}
-
-	@StrutsTagAttribute(description = "Set the icon from jQuery UI Theme Roller that will be used if the grouped row is expanded", defaultValue = "ui-icon-circlesmall-minus")
-	public void setGroupMinusIcon(String groupMinusIcon) {
-		this.groupMinusIcon = groupMinusIcon;
-	}
-
-	@Override
-	@StrutsTagAttribute(description = "Enable sortable columns", type = "Boolean")
-	public void setSortable(String sortable) {
-		this.sortable = sortable;
-	}
-
-	@StrutsTagAttribute(description = "Enable sortable rows", type = "Boolean")
-	public void setSortableRows(String sortableRows) {
-		this.sortableRows = sortableRows;
-	}
+    public static final String JQUERYACTION = "grid";
+    public static final String TEMPLATE = "grid";
+    public static final String TEMPLATE_CLOSE = "grid-close";
+    public static final String COMPONENT_NAME = Grid.class.getName();
+
+    private static final String PARAM_NAVIGATOR_EXTRA_BUTTONS = "navigatorExtraButtons";
+    private static final String PARAM_SUB_GRID = "subGrid";
+    private static final String PARAM_PARENT_GRID = "parentGrid";
+    private static final String PARAM_SUB_GRID_URL = "subGridUrl";
+    private static final String PARAM_SUB_GRID_WIDTH = "subGridWidth";
+    private static final String PARAM_WIDTH = "width";
+    private static final String PARAM_HEIGHT = "height";
+    private static final String PARAM_PAGER = "pager";
+    private static final String PARAM_PAGER_BUTTONS = "pagerButtons";
+    private static final String PARAM_PAGER_INPUT = "pagerInput";
+    private static final String PARAM_PAGER_POSITION = "pagerPosition";
+    private static final String PARAM_ROW_NUM = "rowNum";
+    private static final String PARAM_SORTNAME = "sortname";
+    private static final String PARAM_VIEWRECORDS = "viewrecords";
+    private static final String PARAM_AUTOWIDTH = "autowidth";
+    private static final String PARAM_GRIDVIEW = "gridview";
+    private static final String PARAM_SORTORDER = "sortorder";
+    private static final String PARAM_LOADONCE = "loadonce";
+    private static final String PARAM_MULTISELECT = "multiselect";
+    private static final String PARAM_MULTIBOXONLY = "multiboxonly";
+    private static final String PARAM_EDITURL = "editurl";
+    private static final String PARAM_EDITINLINE = "editinline";
+    private static final String PARAM_CAPTION = "caption";
+    private static final String PARAM_SHRINK_TO_FIT = "shrinkToFit";
+    private static final String PARAM_GRID_MODEL = "gridModel";
+    private static final String PARAM_SCROLL = "scroll";
+    private static final String PARAM_ROW_LIST = "rowList";
+    private static final String PARAM_NAVIGATOR = "navigator";
+    private static final String PARAM_NAVIGATOR_ADD_OPTIONS = "navigatorAddOptions";
+    private static final String PARAM_NAVIGATOR_EDIT_OPTIONS = "navigatorEditOptions";
+    private static final String PARAM_NAVIGATOR_DELETE_OPTIONS = "navigatorDeleteOptions";
+    private static final String PARAM_NAVIGATOR_VIEW_OPTIONS = "navigatorViewOptions";
+    private static final String PARAM_NAVIGATOR_SEARCH_OPTIONS = "navigatorSearchOptions";
+    private static final String PARAM_NAVIGATOR_ADD = "navigatorAdd";
+    private static final String PARAM_NAVIGATOR_DELETE = "navigatorDelete";
+    private static final String PARAM_NAVIGATOR_EDIT = "navigatorEdit";
+    private static final String PARAM_NAVIGATOR_REFRESH = "navigatorRefresh";
+    private static final String PARAM_NAVIGATOR_VIEW = "navigatorView";
+    private static final String PARAM_NAVIGATOR_SEARCH = "navigatorSearch";
+    private static final String PARAM_NAVIGATOR_INLINE_EDIT_BUTTONS = "navigatorInlineEditButtons";
+    private static final String PARAM_NAVIGATOR_CLONE_TO_TOP = "navigatorCloneToTop";
+    private static final String PARAM_CELLURL = "cellurl";
+    private static final String PARAM_MULTISELECT_WIDTH = "multiselectWidth";
+    private static final String PARAM_PAGE = "page";
+    private static final String PARAM_AUTOENCODE = "autoencode";
+    private static final String PARAM_CELL_EDIT = "cellEdit";
+    private static final String PARAM_FOOTERROW = "footerrow";
+    private static final String PARAM_HIDDENGRID = "hiddengrid";
+    private static final String PARAM_HIDEGRID = "hidegrid";
+    private static final String PARAM_HOVERROWS = "hoverrows";
+    private static final String PARAM_ROWNUMBERS = "rownumbers";
+    private static final String PARAM_SCROLLROWS = "scrollrows";
+    private static final String PARAM_FILTER = "filter";
+    private static final String PARAM_FILTER_OPTIONS = "filterOptions";
+    private static final String PARAM_USER_DATA_ON_FOOTER = "userDataOnFooter";
+    private static final String PARAM_ALT_CLASS = "altClass";
+    private static final String PARAM_ALT_ROWS = "altRows";
+    private static final String PARAM_PRM_NAMES = "prmNames";
+    private static final String PARAM_DIRECTION = "direction";
+    private static final String PARAM_RECORDPOS = "recordpos";
+    private static final String PARAM_ROW_TOTAL = "rowTotal";
+    private static final String PARAM_VIEWSORTCOLS = "viewsortcols";
+    private static final String PARAM_TOPPAGER = "toppager";
+    private static final String PARAM_ON_SELECT_ROW_TOPICS = "onSelectRowTopics";
+    private static final String PARAM_ON_SELECT_ALL_TOPICS = "onSelectAllTopics";
+    private static final String PARAM_ON_CELL_SELECT_TOPICS = "onCellSelectTopics";
+    private static final String PARAM_ON_PAGING_TOPICS = "onPagingTopics";
+    private static final String PARAM_ON_SORT_COL_TOPICS = "onSortColTopics";
+    private static final String PARAM_ON_GRID_COMPLETE_TOPICS = "onGridCompleteTopics";
+    private static final String PARAM_ON_EDIT_INLINE_AFTER_SAVE_TOPICS = "onEditInlineAfterSaveTopics";
+    private static final String PARAM_ON_EDIT_INLINE_BEFORE_TOPICS = "onEditInlineBeforeTopics";
+    private static final String PARAM_ON_EDIT_INLINE_ERROR_TOPICS = "onEditInlineErrorTopics";
+    private static final String PARAM_ON_EDIT_INLINE_SUCCESS_TOPICS = "onEditInlineSuccessTopics";
+    private static final String PARAM_ON_CELL_EDIT_ERROR_TOPICS = "onCellEditErrorTopics";
+    private static final String PARAM_ON_CELL_EDIT_SUCCESS_TOPICS = "onCellEditSuccessTopics";
+    private static final String PARAM_ON_SUB_GRID_ROW_EXPANDED = "onSubGridRowExpanded";
+    private static final String PARAM_ON_CLICK_GROUP_TOPICS = "onClickGroupTopics";
+    private static final String PARAM_ON_DBL_CLICK_ROW_TOPICS = "onDblClickRowTopics";
+    private static final String PARAM_ON_RIGHT_CLICK_ROW_TOPICS = "onRightClickRowTopics";
+    private static final String PARAM_RELOAD_TOPICS = "reloadTopics";
+    private static final String PARAM_CONNECT_WITH = "connectWith";
+    private static final String PARAM_GROUP_FIELD = "groupField";
+    private static final String PARAM_GROUP_COLUMN_SHOW = "groupColumnShow";
+    private static final String PARAM_GROUP_TEXT = "groupText";
+    private static final String PARAM_GROUP_ORDER = "groupOrder";
+    private static final String PARAM_GROUP_SUMMARY = "groupSummary";
+    private static final String PARAM_GROUP_SHOW_SUMMARY_ON_HIDE = "groupShowSummaryOnHide";
+    private static final String PARAM_GROUP_PLUS_ICON = "groupPlusIcon";
+    private static final String PARAM_GROUP_MINUS_ICON = "groupMinusIcon";
+    private static final String PARAM_GROUP_DATA_SORTED = "groupDataSorted";
+    private static final String PARAM_GROUP_COLLAPSE = "groupCollapse";
+    private static final String PARAM_SORTABLE_ROWS = "sortableRows";
+
+    private static final String ID_PREFIX_GRID = "grid_";
+
+    protected String width;
+    protected String height;
+    protected String pager;
+    protected String pagerButtons;
+    protected String pagerPosition;
+    protected String pagerInput;
+    protected String rowNum;
+    protected String sortname;
+    protected String viewrecords;
+    protected String gridview;
+    protected String autowidth;
+    protected String sortorder;
+    protected String loadonce;
+    protected String multiselect;
+    protected String multiboxonly;
+    protected String editurl;
+    protected String editinline;
+    protected String caption;
+    protected String shrinkToFit;
+    protected String gridModel;
+    protected String rowList;
+    protected String scroll;
+    protected String navigator;
+    protected String navigatorEditOptions;
+    protected String navigatorAddOptions;
+    protected String navigatorDeleteOptions;
+    protected String navigatorSearchOptions;
+    protected String navigatorViewOptions;
+    protected String navigatorAdd;
+    protected String navigatorDelete;
+    protected String navigatorEdit;
+    protected String navigatorRefresh;
+    protected String navigatorSearch;
+    protected String navigatorView;
+    protected String navigatorInlineEditButtons;
+    protected String navigatorExtraButtons;
+    protected String navigatorCloneToTop;
+    protected String autoencode;
+    protected String cellEdit;
+    protected String cellurl;
+    protected String footerrow;
+    protected String hiddengrid;
+    protected String hidegrid;
+    protected String hoverrows;
+    protected String rownumbers;
+    protected String multiselectWidth;
+    protected String page;
+    protected String scrollrows;
+    protected String filter;
+    protected String subGridWidth;
+    protected String subGridUrl;
+    protected String userDataOnFooter;
+    protected String filterOptions;
+    protected String altClass;
+    protected String altRows;
+    protected String prmNames;
+    protected String direction;
+    protected String recordpos;
+    protected String rowTotal;
+    protected String viewsortcols;
+    protected String toppager;
+
+    protected String onSelectRowTopics;
+    protected String onSelectAllTopics;
+    protected String onPagingTopics;
+    protected String onSortColTopics;
+    protected String onCellSelectTopics;
+    protected String onGridCompleteTopics;
+    protected String onEditInlineBeforeTopics;
+    protected String onEditInlineSuccessTopics;
+    protected String onEditInlineErrorTopics;
+    protected String onEditInlineAfterSaveTopics;
+    protected String onCellEditSuccessTopics;
+    protected String onCellEditErrorTopics;
+    protected String onSubGridRowExpanded;
+    protected String onClickGroupTopics;
+    protected String onDblClickRowTopics;
+    protected String onRightClickRowTopics;
+    protected String reloadTopics;
+    protected String connectWith;
+    protected String groupField;
+    protected String groupColumnShow;
+    protected String groupText;
+    protected String groupCollapse;
+    protected String groupOrder;
+    protected String groupSummary;
+    protected String groupDataSorted;
+    protected String groupShowSummaryOnHide;
+    protected String groupPlusIcon;
+    protected String groupMinusIcon;
+    protected String sortableRows;
+
+    public Grid(ValueStack stack, HttpServletRequest request, HttpServletResponse response) {
+        super(stack, request, response);
+    }
+
+    @Override
+    public String getDefaultOpenTemplate() {
+        return TEMPLATE;
+    }
+
+    @Override
+    protected String getDefaultTemplate() {
+        return TEMPLATE_CLOSE;
+    }
+
+    @Override
+    public void evaluateExtraParams() {
+        super.evaluateExtraParams();
+
+        addParameter(PARAM_JQUERY_ACTION, JQUERYACTION);
+
+        Component parentGrid = findAncestor(Grid.class);
+        if (parentGrid != null) {
+            addParameter(PARAM_SUB_GRID, true);
+            addParameter(PARAM_PARENT_GRID, findString(((Grid) parentGrid).getId()));
+            addParameterIfPresent(PARAM_SUB_GRID_URL, this.subGridUrl);
+            addParameterIfPresent(PARAM_SUB_GRID_WIDTH, this.subGridWidth);
+        }
+        addParameterIfPresent(PARAM_WIDTH, this.width);
+        addParameterIfPresent(PARAM_HEIGHT, this.height);
+        addParameterIfPresent(PARAM_PAGER, this.pager, Boolean.class);
+        addParameterIfPresent(PARAM_PAGER_BUTTONS, this.pagerButtons, Boolean.class);
+        addParameterIfPresent(PARAM_PAGER_INPUT, this.pagerInput, Boolean.class);
+        addParameterIfPresent(PARAM_PAGER_POSITION, this.pagerPosition);
+        addParameterIfPresent(PARAM_ROW_NUM, this.rowNum);
+        addParameterIfPresent(PARAM_SORTNAME, this.sortname);
+        addParameterIfPresent(PARAM_SORTORDER, this.sortorder);
+        addParameterIfPresent(PARAM_VIEWRECORDS, this.viewrecords, Boolean.class);
+        addParameterIfPresent(PARAM_AUTOWIDTH, this.autowidth, Boolean.class);
+        addParameterIfPresent(PARAM_GRIDVIEW, this.gridview, Boolean.class);
+        addParameterIfPresent(PARAM_LOADONCE, this.loadonce, Boolean.class);
+        addParameterIfPresent(PARAM_MULTISELECT, this.multiselect, Boolean.class);
+        addParameterIfPresent(PARAM_MULTIBOXONLY, this.multiboxonly, Boolean.class);
+        addParameterIfPresent(PARAM_EDITURL, this.editurl);
+        addParameterIfPresent(PARAM_EDITINLINE, this.editinline, Boolean.class);
+        addParameterIfPresent(PARAM_CAPTION, this.caption);
+        addParameterIfPresent(PARAM_SHRINK_TO_FIT, this.shrinkToFit, Boolean.class);
+        addParameterIfPresent(PARAM_GRID_MODEL, this.gridModel);
+        addParameterIfPresent(PARAM_SCROLL, this.scroll);
+        addParameterIfPresent(PARAM_ROW_LIST, this.rowList);
+        addParameterIfPresent(PARAM_NAVIGATOR, this.navigator, Boolean.class);
+        addParameterIfPresent(PARAM_NAVIGATOR_ADD_OPTIONS, this.navigatorAddOptions);
+        addParameterIfPresent(PARAM_NAVIGATOR_EDIT_OPTIONS, this.navigatorEditOptions);
+        addParameterIfPresent(PARAM_NAVIGATOR_DELETE_OPTIONS, this.navigatorDeleteOptions);
+        addParameterIfPresent(PARAM_NAVIGATOR_VIEW_OPTIONS, this.navigatorViewOptions);
+        addParameterIfPresent(PARAM_NAVIGATOR_SEARCH_OPTIONS, this.navigatorSearchOptions);
+        addParameterIfPresent(PARAM_NAVIGATOR_ADD, this.navigatorAdd, Boolean.class);
+        addParameterIfPresent(PARAM_NAVIGATOR_DELETE, this.navigatorDelete, Boolean.class);
+        addParameterIfPresent(PARAM_NAVIGATOR_EDIT, this.navigatorEdit, Boolean.class);
+        addParameterIfPresent(PARAM_NAVIGATOR_REFRESH, this.navigatorRefresh, Boolean.class);
+        addParameterIfPresent(PARAM_NAVIGATOR_VIEW, this.navigatorView, Boolean.class);
+        addParameterIfPresent(PARAM_NAVIGATOR_SEARCH, this.navigatorSearch, Boolean.class);
+        addParameterIfPresent(PARAM_NAVIGATOR_EXTRA_BUTTONS, this.navigatorExtraButtons);
+        addParameterIfPresent(PARAM_NAVIGATOR_INLINE_EDIT_BUTTONS, this.navigatorInlineEditButtons, Boolean.class);
+        addParameterIfPresent(PARAM_NAVIGATOR_CLONE_TO_TOP, this.navigatorCloneToTop, Boolean.class);
+        addParameterIfPresent(PARAM_CELLURL, this.cellurl);
+        addParameterIfPresent(PARAM_MULTISELECT_WIDTH, this.multiselectWidth);
+        addParameterIfPresent(PARAM_PAGE, this.page);
+        addParameterIfPresent(PARAM_AUTOENCODE, this.autoencode, Boolean.class);
+        addParameterIfPresent(PARAM_CELL_EDIT, this.cellEdit, Boolean.class);
+        addParameterIfPresent(PARAM_FOOTERROW, this.footerrow, Boolean.class);
+        addParameterIfPresent(PARAM_HIDDENGRID, this.hiddengrid, Boolean.class);
+        addParameterIfPresent(PARAM_HIDEGRID, this.hidegrid, Boolean.class);
+        addParameterIfPresent(PARAM_HOVERROWS, this.hoverrows, Boolean.class);
+        addParameterIfPresent(PARAM_ROWNUMBERS, this.rownumbers, Boolean.class);
+        addParameterIfPresent(PARAM_SCROLLROWS, this.scrollrows, Boolean.class);
+        addParameterIfPresent(PARAM_FILTER, this.filter, Boolean.class);
+        addParameterIfPresent(PARAM_FILTER_OPTIONS, this.filterOptions);
+        addParameterIfPresent(PARAM_USER_DATA_ON_FOOTER, this.userDataOnFooter, Boolean.class);
+        addParameterIfPresent(PARAM_ALT_CLASS, this.altClass);
+        addParameterIfPresent(PARAM_ALT_ROWS, this.altRows, Boolean.class);
+        addParameterIfPresent(PARAM_PRM_NAMES, this.prmNames);
+        addParameterIfPresent(PARAM_DIRECTION, this.direction);
+        addParameterIfPresent(PARAM_RECORDPOS, this.recordpos);
+        addParameterIfPresent(PARAM_ROW_TOTAL, this.rowTotal, Integer.class);
+        addParameterIfPresent(PARAM_VIEWSORTCOLS, this.viewsortcols);
+        addParameterIfPresent(PARAM_TOPPAGER, this.toppager, Boolean.class);
+        addParameterIfPresent(PARAM_ON_SELECT_ROW_TOPICS, this.onSelectRowTopics);
+        addParameterIfPresent(PARAM_ON_SELECT_ALL_TOPICS, this.onSelectAllTopics);
+        addParameterIfPresent(PARAM_ON_CELL_SELECT_TOPICS, this.onCellSelectTopics);
+        addParameterIfPresent(PARAM_ON_PAGING_TOPICS, this.onPagingTopics);
+        addParameterIfPresent(PARAM_ON_SORT_COL_TOPICS, this.onSortColTopics);
+        addParameterIfPresent(PARAM_ON_GRID_COMPLETE_TOPICS, this.onGridCompleteTopics);
+        addParameterIfPresent(PARAM_ON_EDIT_INLINE_AFTER_SAVE_TOPICS, this.onEditInlineAfterSaveTopics);
+        addParameterIfPresent(PARAM_ON_EDIT_INLINE_BEFORE_TOPICS, this.onEditInlineBeforeTopics);
+        addParameterIfPresent(PARAM_ON_EDIT_INLINE_ERROR_TOPICS, this.onEditInlineErrorTopics);
+        addParameterIfPresent(PARAM_ON_EDIT_INLINE_SUCCESS_TOPICS, this.onEditInlineSuccessTopics);
+        addParameterIfPresent(PARAM_ON_CELL_EDIT_ERROR_TOPICS, this.onCellEditErrorTopics);
+        addParameterIfPresent(PARAM_ON_CELL_EDIT_SUCCESS_TOPICS, this.onCellEditSuccessTopics);
+        addParameterIfPresent(PARAM_ON_SUB_GRID_ROW_EXPANDED, this.onSubGridRowExpanded);
+        addParameterIfPresent(PARAM_ON_CLICK_GROUP_TOPICS, this.onClickGroupTopics);
+        addParameterIfPresent(PARAM_ON_DBL_CLICK_ROW_TOPICS, this.onDblClickRowTopics);
+        addParameterIfPresent(PARAM_ON_RIGHT_CLICK_ROW_TOPICS, this.onRightClickRowTopics);
+        addParameterIfPresent(PARAM_RELOAD_TOPICS, this.reloadTopics);
+        addParameterIfPresent(PARAM_CONNECT_WITH, this.connectWith);
+        addParameterIfPresent(PARAM_GROUP_FIELD, this.groupField);
+        addParameterIfPresent(PARAM_GROUP_COLUMN_SHOW, this.groupColumnShow);
+        addParameterIfPresent(PARAM_GROUP_TEXT, this.groupText);
+        addParameterIfPresent(PARAM_GROUP_ORDER, this.groupOrder);
+        addParameterIfPresent(PARAM_GROUP_SUMMARY, this.groupSummary);
+        addParameterIfPresent(PARAM_GROUP_SHOW_SUMMARY_ON_HIDE, this.groupShowSummaryOnHide, Boolean.class);
+        addParameterIfPresent(PARAM_GROUP_PLUS_ICON, this.groupPlusIcon);
+        addParameterIfPresent(PARAM_GROUP_MINUS_ICON, this.groupMinusIcon);
+        addParameterIfPresent(PARAM_GROUP_DATA_SORTED, this.groupDataSorted, Boolean.class);
+        addParameterIfPresent(PARAM_GROUP_COLLAPSE, this.groupCollapse, Boolean.class);
+
+        if (sortableRows != null) {
+            String sortableValue = findString(sortableRows);
+            if (BooleanUtils.toBoolean(sortableValue)) {
+                addParameter(PARAM_SORTABLE_ROWS, Boolean.TRUE);
+            }
+        }
+        addGeneratedIdParam(ID_PREFIX_GRID);
+    }
+
+    @Override
+    @StrutsTagSkipInheritance
+    public void setTheme(String theme) {
+        super.setTheme(theme);
+    }
+
+    @Override
+    public String getTheme() {
+        return "jquery";
+    }
+
+    @StrutsTagAttribute(description = "If this option is not set, the width of the grid is a sum of the widths of the columns defined in the colModel (in pixels). If this option is set, the initial width of each column is set according to the value of shrinkToFit option.")
+    public void setWidth(String width) {
+        this.width = width;
+    }
+
+    @StrutsTagAttribute(description = "The height of the grid. Can be set as number e.g. 400. Default: auto")
+    public void setHeight(String height) {
+        this.height = height;
+    }
+
+    @StrutsTagAttribute(description = "Defines that we want to use a pager bar to navigate through the records. This must be a true or false.", defaultValue = "false", type = "Boolean")
+    public void setPager(String pager) {
+        this.pager = pager;
+    }
+
+    @StrutsTagAttribute(description = "Determines if the Pager buttons should be shown if pager is available. Also valid only if pager is set correctly. The buttons are placed in the pager bar.", defaultValue = "true", type = "Boolean")
+    public void setPagerButtons(String pagerButtons) {
+        this.pagerButtons = pagerButtons;
+    }
+
+    @StrutsTagAttribute(description = "Determines the position of the pager in the grid. By default the pager element when created is divided in 3 parts. Can be left, center, right", defaultValue = "center")
+    public void setPagerPosition(String pagerPosition) {
+        this.pagerPosition = pagerPosition;
+    }
+
+    @StrutsTagAttribute(description = "DDetermines if the input box, where the user can change the number of requested page, should be available. The input box appear in the pager bar.", defaultValue = "true", type = "Boolean")
+    public void setPagerInput(String pagerInput) {
+        this.pagerInput = pagerInput;
+    }
+
+    @StrutsTagAttribute(description = "Sets how many records we want to view in the grid. This parameter is passed to the url for use by the server routine retrieving the data. Note that if you set this parameter to 10 (i.e. retrieve 10 records) and your server return 15 then only 10 records will be loaded. Set this parameter to -1 (unlimited) to disable this checking. Default: 20")
+    public void setRowNum(String rowNum) {
+        this.rowNum = rowNum;
+    }
+
+    @StrutsTagAttribute(description = "The initial sorting name. This parameter is added to the url. If set and the index (name) match the name from colModel then to this column by default is added a image sorting icon, according to the parameter sortorder (below).")
+    public void setSortname(String sortname) {
+        this.sortname = sortname;
+    }
+
+    @StrutsTagAttribute(description = "Defines whether we want to display the number of total records from the query in the pager bar.", defaultValue = "false", type = "Boolean")
+    public void setViewrecords(String viewrecords) {
+        this.viewrecords = viewrecords;
+    }
+
+    @StrutsTagAttribute(description = "Insert the entry row at once with a jQuery append. The result is impressive - about 3-5 times faster. If set to true we can not use treeGrid, subGrid, or afterInsertRow event.", defaultValue = "false", type = "Boolean")
+    public void setGridview(String gridview) {
+        this.gridview = gridview;
+    }
+
+    @StrutsTagAttribute(description = "When set to true, the grid width is recalculated automatically to the width of the parent element. This is done only initially when the grid is created.", defaultValue = "false", type = "Boolean")
+    public void setAutowidth(String autowidth) {
+        this.autowidth = autowidth;
+    }
+
+    @StrutsTagAttribute(description = "The initial sorting order.This parameter is added to the url - see prnNames. Two possible values - asc or desc. Default asc")
+    public void setSortorder(String sortorder) {
+        this.sortorder = sortorder;
+    }
+
+    @StrutsTagAttribute(description = "If this flag is set to true, the grid loads the data from the server only once. After the first request all further manipulations are done on the client side. The functions of the pager (if present) are disabled.", defaultValue = "false", type = "Boolean")
+    public void setLoadonce(String loadonce) {
+        this.loadonce = loadonce;
+    }
+
+    @StrutsTagAttribute(description = "If this flag is set to true a multi selection of rows is enabled. A new column at left side is added.", defaultValue = "false", type = "Boolean")
+    public void setMultiselect(String multiselect) {
+        this.multiselect = multiselect;
+    }
+
+    @StrutsTagAttribute(description = "This option works only when multiselect = true. When multiselect is set to true, clicking anywhere on a row selects that row; when multiboxonly is also set to true, the multiselection is done only when the checkbox is clicked (Yahoo style). Clicking in any other row (suppose the checkbox is not clicked) deselects all rows and the current row is selected.", defaultValue = "false", type = "Boolean")
+    public void setMultiboxonly(String multiboxonly) {
+        this.multiboxonly = multiboxonly;
+    }
+
+    @StrutsTagAttribute(description = "Defines the url for inline and form editing.")
+    public void setEditurl(String editurl) {
+        this.editurl = editurl;
+    }
+
+    @StrutsTagAttribute(description = "Enable editing inline. Default: false", defaultValue = "false", type = "Boolean")
+    public void setEditinline(String editinline) {
+        this.editinline = editinline;
+    }
+
+    @StrutsTagAttribute(description = "Defines the Caption layer for the grid. This caption appear above the Header layer. If the string is empty the caption does not appear.")
+    public void setCaption(String caption) {
+        this.caption = caption;
+    }
+
+    @StrutsTagAttribute(description = "This option describes the type of calculation of the initial width of each column against with the width of the grid. If the value is true and the value in width option is set then: Every column width is scaled according to the defined option width.", defaultValue = "true", type = "Boolean")
+    public void setShrinkToFit(String shrinkToFit) {
+        this.shrinkToFit = shrinkToFit;
+    }
+
+    @StrutsTagAttribute(description = "Name of you grid model. Must be a Collection", required = true)
+    public void setGridModel(String gridModel) {
+        this.gridModel = gridModel;
+    }
+
+    @StrutsTagAttribute(description = "An array to construct a select box element in the pager in which we can change the number of the visible rows. e.g. 10,15,20")
+    public void setRowList(String rowList) {
+        this.rowList = rowList;
+    }
+
+    @StrutsTagAttribute(description = "Creates dynamic scrolling grids. When enabled, the pager elements are disabled and we can use the vertical scrollbar to load data. When set to true the grid will always hold all the items from the start through to the latest point ever visited.", defaultValue = "false")
+    public void setScroll(String scroll) {
+        this.scroll = scroll;
+    }
+
+    @StrutsTagAttribute(description = "Navigator is a method that can add predefined actions like editing, adding, deleting, and searching. This must be a true or false.", defaultValue = "false", type = "Boolean")
+    public void setNavigator(String navigator) {
+        this.navigator = navigator;
+    }
+
+    @StrutsTagAttribute(description = "Edit Options for Navigator. e.g. {height:280,reloadAfterSubmit:false},")
+    public void setNavigatorEditOptions(String navigatorEditOptions) {
+        this.navigatorEditOptions = navigatorEditOptions;
+    }
+
+    @StrutsTagAttribute(description = "Add Options for Navigator. e.g. {height:280,reloadAfterSubmit:false},")
+    public void setNavigatorAddOptions(String navigatorAddOptions) {
+        this.navigatorAddOptions = navigatorAddOptions;
+    }
+
+    @StrutsTagAttribute(description = "Delete Options for Navigator. e.g. {height:280,reloadAfterSubmit:false},")
+    public void setNavigatorDeleteOptions(String navigatorDeleteOptions) {
+        this.navigatorDeleteOptions = navigatorDeleteOptions;
+    }
+
+    @StrutsTagAttribute(description = "Search Options for Navigator. e.g. {height:280,reloadAfterSubmit:false},")
+    public void setNavigatorSearchOptions(String navigatorSearchOptions) {
+        this.navigatorSearchOptions = navigatorSearchOptions;
+    }
+
+    @StrutsTagAttribute(description = "View Options for Navigator. e.g. {sopt:['cn','bw','eq','ne','lt','gt','ew']},")
+    public void setNavigatorViewOptions(String navigatorViewOptions) {
+        this.navigatorViewOptions = navigatorViewOptions;
+    }
+
+    @StrutsTagAttribute(description = "Clones all the actions from the bottom pager to the top pager if defined.", defaultValue = "false", type = "Boolean")
+    public void setNavigatorCloneToTop(String navigatorCloneToTop) {
+        this.navigatorCloneToTop = navigatorCloneToTop;
+    }
+
+    @StrutsTagAttribute(description = "When set to true encodes (html encode) the incoming (from server) and posted data (from editing modules). By example < will be converted to &lt;", defaultValue = "true", type = "Boolean")
+    public void setAutoencode(String autoencode) {
+        this.autoencode = autoencode;
+    }
+
+    @StrutsTagAttribute(description = "Enables (disables) cell editing. See Cell Editing for more details", defaultValue = "false", type = "Boolean")
+    public void setCellEdit(String cellEdit) {
+        this.cellEdit = cellEdit;
+    }
+
+    @StrutsTagAttribute(description = "the url where the cell is to be saved.", defaultValue = "false", type = "Boolean")
+    public void setCellurl(String cellurl) {
+        this.cellurl = cellurl;
+    }
+
+    @StrutsTagAttribute(description = "If set to true this will place a footer table with one row below the gird records and above the pager.", defaultValue = "false", type = "Boolean")
+    public void setFooterrow(String footerrow) {
+        this.footerrow = footerrow;
+    }
+
+    @StrutsTagAttribute(description = "If set to true the grid initially is hidden. The data is not loaded (no request is sent) and only the caption layer is shown. When the show/hide button is clicked the first time to show grid, the request is sent to the server, the data is loaded, and grid is shown. From this point we have a regular grid.", defaultValue = "false", type = "Boolean")
+    public void setHiddengrid(String hiddengrid) {
+        this.hiddengrid = hiddengrid;
+    }
+
+    @StrutsTagAttribute(description = "Enables or disables the show/hide grid button, which appears on the right side of the Caption layer. Takes effect only if the caption property is not an empty string.", defaultValue = "false", type = "Boolean")
+    public void setHidegrid(String hidegrid) {
+        this.hidegrid = hidegrid;
+    }
+
+    @StrutsTagAttribute(description = "When set to false the mouse hovering is disabled in the grid data rows.", defaultValue = "false", type = "Boolean")
+    public void setHoverrows(String hoverrows) {
+        this.hoverrows = hoverrows;
+    }
+
+    @StrutsTagAttribute(description = "If this option is set to true, a new column at left of the grid is added. The purpose of this column is to count the number of available rows, beginning from 1. In this case colModel is extended automatically with new element with name - 'rn'. Also, be careful not to use the name 'rn' in gridModel", defaultValue = "false", type = "Boolean")
+    public void setRownumbers(String rownumbers) {
+        this.rownumbers = rownumbers;
+    }
+
+    @StrutsTagAttribute(description = "etermines the width of the multiselect column if multiselect is set to true.")
+    public void setMultiselectWidth(String multiselectWidth) {
+        this.multiselectWidth = multiselectWidth;
+    }
+
+    @StrutsTagAttribute(description = "Set the initial number of page when we make the request.This parameter is passed to the url for use by the server routine retrieving the data", defaultValue = "1")
+    public void setPage(String page) {
+        this.page = page;
+    }
+
+    @StrutsTagAttribute(description = "When enabled, selecting a row with setSelection scrolls the grid so that the selected row is visible.", defaultValue = "false", type = "Boolean")
+    public void setScrollrows(String scrollrows) {
+        this.scrollrows = scrollrows;
+    }
+
+    @StrutsTagAttribute(description = "Enables or disables the add action in the navigator. When the button is clicked a editGridRow with parameter new method is executed", defaultValue = "true", type = "Boolean")
+    public void setNavigatorAdd(String navigatorAdd) {
+        this.navigatorAdd = navigatorAdd;
+    }
+
+    @StrutsTagAttribute(description = "Enables or disables the delete action in the navigator. When the button is clicked a delGridRow method is executed.", defaultValue = "true", type = "Boolean")
+    public void setNavigatorDelete(String navigatorDelete) {
+        this.navigatorDelete = navigatorDelete;
+    }
+
+    @StrutsTagAttribute(description = "Enables or disables the edit action in the navigator. When the button is clicked a editGridRow method is executed with parameter the - current selected row", defaultValue = "true", type = "Boolean")
+    public void setNavigatorEdit(String navigatorEdit) {
+        this.navigatorEdit = navigatorEdit;
+    }
+
+    @StrutsTagAttribute(description = "Enables or disables the refresh button in the pager. When the button is clicked a trigger(reloadGrid) is executed and the search parameters are cleared", defaultValue = "true", type = "Boolean")
+    public void setNavigatorRefresh(String navigatorRefresh) {
+        this.navigatorRefresh = navigatorRefresh;
+    }
+
+    @StrutsTagAttribute(description = "Enables or disables the search button in the pager.When the button is clicked a searchGrid method is executed", defaultValue = "true", type = "Boolean")
+    public void setNavigatorSearch(String navigatorSearch) {
+        this.navigatorSearch = navigatorSearch;
+    }
+
+    @StrutsTagAttribute(description = "Enables or disables the view button in the pager. When the button is clicked a viewGridRow method is executed", defaultValue = "false", type = "Boolean")
+    public void setNavigatorView(String navigatorView) {
+        this.navigatorView = navigatorView;
+    }
+
+    @StrutsTagAttribute(description = "Add extra buttons to Navigator. e.g.: { seperator: { title : 'seperator'  }, hidebutton : { title : 'Show Hide', icon: 'ui-icon-gear', topic: showHideGrid} }")
+    public void setNavigatorExtraButtons(String navigatorExtraButtons) {
+        this.navigatorExtraButtons = navigatorExtraButtons;
+    }
+
+    @StrutsTagAttribute(description = "Show buttons for edit and add rows in case of editinline is true.", defaultValue = "true", type = "Boolean")
+    public void setNavigatorInlineEditButtons(String navigatorInlineEditButtons) {
+        this.navigatorInlineEditButtons = navigatorInlineEditButtons;
+    }
+
+    @StrutsTagAttribute(description = "This method construct searching creating input elements just below the header elements of the grid.", defaultValue = "false", type = "Boolean")
+    public void setFilter(String filter) {
+        this.filter = filter;
+    }
+
+    @StrutsTagAttribute(description = "Determines the width of the subGrid column if subgrid is enabled.")
+    public void setSubGridWidth(String subGridWidth) {
+        this.subGridWidth = subGridWidth;
+    }
+
+    @StrutsTagAttribute(description = "This option has effect only if subGrid option is set to true. This option points to the file from which we get the data for the subgrid. jqGrid adds the id of the row to this url as parameter.")
+    public void setSubGridUrl(String subGridUrl) {
+        this.subGridUrl = subGridUrl;
+    }
+
+    @StrutsTagAttribute(description = "When set to true we directly place the user data array userData at footer. The rules are as follow: If the userData array contain name which is equal to those of colModel then the value is placed in that column.If there are no such values nothing is palced. Note that if this option is used we use the current formatter options (if available) for that column.")
+    public void setUserDataOnFooter(String userDataOnFooter) {
+        this.userDataOnFooter = userDataOnFooter;
+    }
+
+    @StrutsTagAttribute(description = "Options for Filter Settings as JavaScript Object. e.g. { autosearch : false, formtype : vertical }")
+    public void setFilterOptions(String filterOptions) {
+        this.filterOptions = filterOptions;
+    }
+
+    @StrutsTagAttribute(description = "The class that is used for alternate rows. You can construct your own class and replace this value. This option is valid only if altRows options is set to true", defaultValue = "ui-priority-secondary")
+    public void setAltClass(String altClass) {
+        this.altClass = altClass;
+    }
+
+    @StrutsTagAttribute(description = "Set a zebra-striped grid", defaultValue = "false", type = "Boolean")
+    public void setAltRows(String altRows) {
+        this.altRows = altRows;
+    }
+
+    @StrutsTagAttribute(description = "Customizes names of the fields sent to the server on a Post. When some parameter is set to null they will be not sended to the server.", defaultValue = "{page:\"page\",rows:\"rows\", sort: \"sidx\",order: \"sord\", search:\"_search\", nd:\"nd\", id:\"id\",oper:\"oper\",editoper:\"edit\",addoper:\"add\",deloper:\"del\"}")
+    public void setPrmNames(String prmNames) {
+        this.prmNames = prmNames;
+    }
+
+    @StrutsTagAttribute(description = "Determines the language direction in grid. The default is 'ltr' (Left To Right language). When set to 'rtl' (Right To Left) the grid automatically do the needed.", defaultValue = "ltr")
+    public void setDirection(String direction) {
+        this.direction = direction;
+    }
+
+    @StrutsTagAttribute(description = "Determines the position of the record information in the pager. Can be left, center, right", defaultValue = "right")
+    public void setRecordpos(String recordpos) {
+        this.recordpos = recordpos;
+    }
+
+    @StrutsTagAttribute(description = "When set this parameter can instruct the server to load the total number of rows needed to work on. Note that rowNum determines the total records displayed in the grid, while rowTotal the total rows on which we operate. When this parameter is set we send a additional parameter to server named totalrows. You can check for this parameter and if it is available you can replace the rows parameter with this one. Mostly this parameter can be combined wit loadonce parameter set to true.", defaultValue = "null", type = "Integer")
+    public void setRowTotal(String rowTotal) {
+        this.rowTotal = rowTotal;
+    }
+
+    @StrutsTagAttribute(description = "The purpose of this parameter is to define different look and behavior of sorting icons that appear near the header. This parameter is array with the following default options viewsortcols : [false,'vertical',true]. The first parameter determines if all icons should be viewed at the same time when all columns have sort property set to true. The default of false determines that only the icons of the current sorting column should be viewed. Setting this parameter to true causes all icons in all sortable columns to be viewed. The second parameter determines how icons should be placed - vertical means that the sorting icons are one under another. 'horizontal' means that the icons should be one near other. The third parameter determines the click functionality. If set to true the columns are sorted if the header is clicked. If set to false the columns are sorted only when the icons are clicked. Important note: When set a third parameter to false be a sure that the first parameter is set to true, otherwise you will loose the sorting.", defaultValue = "false")
+    public void setViewsortcols(String viewsortcols) {
+        this.viewsortcols = viewsortcols;
+    }
+
+    @StrutsTagAttribute(description = "When enabled this option place a pager element at top of the grid below the caption (if available).", defaultValue = "false", type = "Boolean")
+    public void setToppager(String toppager) {
+        this.toppager = toppager;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published when a row is selected")
+    public void setOnSelectRowTopics(String onSelectRowTopics) {
+        this.onSelectRowTopics = onSelectRowTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published when multiselect option is true and you click on the header checkbox.")
+    public void setOnSelectAllTopics(String onSelectAllTopics) {
+        this.onSelectAllTopics = onSelectAllTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published after click on page button and before populating the data. Parameter: pgButton")
+    public void setOnPagingTopics(String onPagingTopics) {
+        this.onPagingTopics = onPagingTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published immediately after sortable column was clicked and before sorting the data. Parameters: index is the index name from colModel, iCol is the index of column, sortorder is the new sorting order - can be 'asc' or 'desc'")
+    public void setOnSortColTopics(String onSortColTopics) {
+        this.onSortColTopics = onSortColTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published when we click on particular cell in the grid. Parameters: rowid is the id of the row, iCol is the index of the cell, cellcontent is the content of the cell, e is the event object element where we click.")
+    public void setOnCellSelectTopics(String onCellSelectTopics) {
+        this.onCellSelectTopics = onCellSelectTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published after all the data is loaded into the grid and all other processes are complete.")
+    public void setOnGridCompleteTopics(String onGridCompleteTopics) {
+        this.onGridCompleteTopics = onGridCompleteTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published after successfully accessing the row for editing, prior to allowing user access to the input fields.")
+    public void setOnEditInlineBeforeTopics(String onEditInlineBeforeTopics) {
+        this.onEditInlineBeforeTopics = onEditInlineBeforeTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published is called immediately after the request is successful.")
+    public void setOnEditInlineSuccessTopics(String onEditInlineSuccessTopics) {
+        this.onEditInlineSuccessTopics = onEditInlineSuccessTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published is called immediately after the data is saved to the server")
+    public void setOnEditInlineErrorTopics(String onEditInlineErrorTopics) {
+        this.onEditInlineErrorTopics = onEditInlineErrorTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published is called immediately after the data is saved to the server")
+    public void setOnEditInlineAfterSaveTopics(String onEditInlineAfterSaveTopics) {
+        this.onEditInlineAfterSaveTopics = onEditInlineAfterSaveTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published is called immediately after the cell has been successfully saved.")
+    public void setOnCellEditSuccessTopics(String onCellEditSuccessTopics) {
+        this.onCellEditSuccessTopics = onCellEditSuccessTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published is called immediately if there is a server error.")
+    public void setOnCellEditErrorTopics(String onCellEditErrorTopics) {
+        this.onCellEditErrorTopics = onCellEditErrorTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published when subgrid row is expanded. Set event.originalEvent.orginal.proceed = false in your topic to prevent default action.")
+    public void setOnSubGridRowExpanded(String onSubGridRowExpanded) {
+        this.onSubGridRowExpanded = onSubGridRowExpanded;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published when a group is clicked.")
+    public void setOnClickGroupTopics(String onClickGroupTopics) {
+        this.onClickGroupTopics = onClickGroupTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published row was double clicked.")
+    public void setOnDblClickRowTopics(String onDblClickRowTopics) {
+        this.onDblClickRowTopics = onDblClickRowTopics;
+    }
+
+    @StrutsTagAttribute(description = "A comma delimited list of topics that published after row was right clicked. Note - this event does not work in Opera browsers, since Opera does not support oncontextmenu event")
+    public void setOnRightClickRowTopics(String onRightClickRowTopics) {
+        this.onRightClickRowTopics = onRightClickRowTopics;
+    }
+
+    @Override
+    @StrutsTagAttribute(name = "reloadTopics", description = "A comma delimited list of topics that will cause this grid to reload")
+    public void setReloadTopics(String reloadTopics) {
+        this.reloadTopics = reloadTopics;
+    }
+
+    @StrutsTagAttribute(description = "Determines the target grid(s) to which the row should be dropped. The option is a string. In case of more than one grid the ids should be delemited with comma - i.e #grid1, #grid2 ", defaultValue = "empty string")
+    public void setConnectWith(String connectWith) {
+        this.connectWith = connectWith;
+    }
+
+    @StrutsTagAttribute(description = "Defines the name from  colModel  on which we group. The first value is the first lavel, the second values is the second level and etc. Currently only one level is supported. e.g. ['name']")
+    public void setGroupField(String groupField) {
+        this.groupField = groupField;
+    }
+
+    @StrutsTagAttribute(description = "Show/Hide the column on which we group. The value here should be a boolean true/false for the group level. If the grouping is enabled we set this value to true. e.g. [true]")
+    public void setGroupColumnShow(String groupColumnShow) {
+        this.groupColumnShow = groupColumnShow;
+    }
+
+    @StrutsTagAttribute(description = "Defines the grouping header text for the group level that will be displayed in the grid. By default if defined the value if {0} which means that the group value name will be displayed. It is possible to specify another value {1} which meant the the total cont of this group will be displayed too. It is possible to set here any valid html content. e.g. ['<b>{0} - {1} Item(s)</b>'] ")
+    public void setGroupText(String groupText) {
+        this.groupText = groupText;
+    }
+
+    @StrutsTagAttribute(description = "Defines if the initially the grid should show or hide the detailed rows of the group.", defaultValue = "false", type = "Boolean")
+    public void setGroupCollapse(String groupCollapse) {
+        this.groupCollapse = groupCollapse;
+    }
+
+    @StrutsTagAttribute(description = "Defines the initial sort order of the group level. Can be asc for ascending or desc for descending order. If the grouping is enabled the default value is asc. e.g. ['asc']")
+    public void setGroupOrder(String groupOrder) {
+        this.groupOrder = groupOrder;
+    }
+
+    @StrutsTagAttribute(description = "Enable or disable the summary (footer) row of the current group level. If grouping is set the default value for the group is false. e.g. [true]")
+    public void setGroupSummary(String groupSummary) {
+        this.groupSummary = groupSummary;
+    }
+
+    @StrutsTagAttribute(description = "If this parameter is set to true we send a additional parameter to the server in order to tell him to sort the data. This way all the sorting is done at server leaving the grid only to display the grouped data. If this parameter is false additionally before to display the data we make our own sorting in order to support grouping. This of course slow down the speed on relative big data. This parameter is not valid is the datatype is local.", defaultValue = "false", type = "Boolean")
+    public void setGroupDataSorted(String groupDataSorted) {
+        this.groupDataSorted = groupDataSorted;
+    }
+
+    @StrutsTagAttribute(description = "Show or hide the summary (footer) row when we collapse the group.", defaultValue = "false", type = "Boolean")
+    public void setGroupShowSummaryOnHide(String groupShowSummaryOnHide) {
+        this.groupShowSummaryOnHide = groupShowSummaryOnHide;
+    }
+
+    @StrutsTagAttribute(description = "Set the icon from jQuery UI Theme Roller that will be used if the grouped row is collapsed", defaultValue = "ui-icon-circlesmall-plus")
+    public void setGroupPlusIcon(String groupPlusIcon) {
+        this.groupPlusIcon = groupPlusIcon;
+    }
+
+    @StrutsTagAttribute(description = "Set the icon from jQuery UI Theme Roller that will be used if the grouped row is expanded", defaultValue = "ui-icon-circlesmall-minus")
+    public void setGroupMinusIcon(String groupMinusIcon) {
+        this.groupMinusIcon = groupMinusIcon;
+    }
+
+    @Override
+    @StrutsTagAttribute(description = "Enable sortable columns", type = "Boolean")
+    public void setSortable(String sortable) {
+        this.sortable = sortable;
+    }
+
+    @StrutsTagAttribute(description = "Enable sortable rows", type = "Boolean")
+    public void setSortableRows(String sortableRows) {
+        this.sortableRows = sortableRows;
+    }
 
 }

--- a/struts2-jquery-grid-plugin/src/main/resources/template/js/struts2/jquery.grid.struts2.js
+++ b/struts2-jquery-grid-plugin/src/main/resources/template/js/struts2/jquery.grid.struts2.js
@@ -323,7 +323,7 @@
 					if (o.sortableRows) {
 						self.log('sortable rows for : ' + o.id);
 						
-						if (!soo) {
+						if (!soo && soos) {
 							soo = eval("( " + soos + " )");
 						} else {
 							soo = {};

--- a/struts2-jquery-grid-plugin/src/site/docs/grid.html
+++ b/struts2-jquery-grid-plugin/src/site/docs/grid.html
@@ -12,7 +12,7 @@ Please do not edit it directly.
 		<h2>Description</h2>
 		<p>
 		<!-- START SNIPPET: tagdescription -->
-		Render an grid from a JSON Result.
+		Render a grid from a JSON Result.
 		<!-- END SNIPPET: tagdescription -->
 		</p>
 

--- a/struts2-jquery-grid-showcase/pom.xml
+++ b/struts2-jquery-grid-showcase/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     <artifactId>struts2-jquery-grid-showcase</artifactId>
     <name>Struts 2 jQuery Grid Showcase</name>

--- a/struts2-jquery-grid-showcase/pom.xml
+++ b/struts2-jquery-grid-showcase/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <spring.version>4.1.0.RELEASE</spring.version>
         <hibernate.version>4.3.6.Final</hibernate.version>
-        <log4j2.version>2.7</log4j2.version>
+        <log4j2.version>2.9.0</log4j2.version>
     </properties>
 
     <dependencies>

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -28,6 +28,7 @@
     <phantomjsdriver.version>1.4.3</phantomjsdriver.version>
     <commons-codec.version>1.10</commons-codec.version>
     <commons-io.version>2.5</commons-io.version>
+    <commons-lang.version>3.6</commons-lang.version>
 
     <failsafe.test.category>com.jgeppert.jquery.junit.category.HtmlUnitCategory</failsafe.test.category>
     <failsafe.webdriver.name>HtmlUnit</failsafe.webdriver.name>
@@ -231,6 +232,12 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${commons-io.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang.version}</version>
       </dependency>
 
       <dependency>

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -21,7 +21,7 @@
     <maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
     <!-- dependencies -->
     <junit.version>4.12</junit.version>
-    <selenium.version>3.2.0</selenium.version>
+    <selenium.version>3.5.2</selenium.version>
     <htmlunit-driver.version>2.27</htmlunit-driver.version>
     <lombok.version>1.16.2</lombok.version>
 

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -24,6 +24,7 @@
     <selenium.version>3.5.2</selenium.version>
     <htmlunit-driver.version>2.27</htmlunit-driver.version>
     <lombok.version>1.16.2</lombok.version>
+    <guava.version>23.0</guava.version>
 
     <failsafe.test.category>com.jgeppert.jquery.junit.category.HtmlUnitCategory</failsafe.test.category>
     <failsafe.webdriver.name>HtmlUnit</failsafe.webdriver.name>
@@ -199,6 +200,13 @@
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>htmlunit-driver</artifactId>
         <version>${htmlunit-driver.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -248,6 +248,13 @@
       </dependency>
 
       <dependency>
+        <groupId>org.seleniumhq.selenium</groupId>
+        <artifactId>selenium-remote-driver</artifactId>
+        <version>${selenium.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>${lombok.version}</version>

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -27,6 +27,7 @@
     <guava.version>23.0</guava.version>
     <phantomjsdriver.version>1.4.3</phantomjsdriver.version>
     <commons-codec.version>1.10</commons-codec.version>
+    <commons-io.version>2.5</commons-io.version>
 
     <failsafe.test.category>com.jgeppert.jquery.junit.category.HtmlUnitCategory</failsafe.test.category>
     <failsafe.webdriver.name>HtmlUnit</failsafe.webdriver.name>
@@ -224,6 +225,12 @@
         <artifactId>commons-codec</artifactId>
         <version>${commons-codec.version}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons-io.version}</version>
       </dependency>
 
       <dependency>

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -241,6 +241,13 @@
       </dependency>
 
       <dependency>
+        <groupId>org.seleniumhq.selenium</groupId>
+        <artifactId>selenium-api</artifactId>
+        <version>${selenium.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>${lombok.version}</version>

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -255,6 +255,13 @@
       </dependency>
 
       <dependency>
+        <groupId>org.seleniumhq.selenium</groupId>
+        <artifactId>selenium-support</artifactId>
+        <version>${selenium.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>${lombok.version}</version>

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- plugins -->
-        <jetty-maven-plugin.version>9.4.7.v20170914</jetty-maven-plugin.version>
+        <jetty-maven-plugin.version>9.4.8.v20171121</jetty-maven-plugin.version>
         <maven-failsafe-plugin.version>2.20.1</maven-failsafe-plugin.version>
         <!-- dependencies -->
         <junit.version>4.12</junit.version>

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -22,7 +22,7 @@
         <maven-failsafe-plugin.version>2.20.1</maven-failsafe-plugin.version>
         <!-- dependencies -->
         <junit.version>4.12</junit.version>
-        <selenium.version>3.6.0</selenium.version>
+        <selenium.version>3.5.3</selenium.version>
         <htmlunit-driver.version>2.27</htmlunit-driver.version>
         <lombok.version>1.16.18</lombok.version>
         <guava.version>23.0</guava.version>

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -22,7 +22,7 @@
     <!-- dependencies -->
     <junit.version>4.12</junit.version>
     <selenium.version>3.2.0</selenium.version>
-    <htmlunit-driver.version>2.25</htmlunit-driver.version>
+    <htmlunit-driver.version>2.27</htmlunit-driver.version>
     <lombok.version>1.16.2</lombok.version>
 
     <failsafe.test.category>com.jgeppert.jquery.junit.category.HtmlUnitCategory</failsafe.test.category>

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     <artifactId>struts2-jquery-integration-tests</artifactId>
     <name>Struts 2 jQuery Integration Tests</name>

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -1,281 +1,282 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.jgeppert.struts2.jquery</groupId>
-    <artifactId>struts2-jquery</artifactId>
-    <version>4.0.3-SNAPSHOT</version>
-  </parent>
-  <artifactId>struts2-jquery-integration-tests</artifactId>
-  <name>Struts 2 jQuery Integration Tests</name>
-  <packaging>war</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.jgeppert.struts2.jquery</groupId>
+        <artifactId>struts2-jquery</artifactId>
+        <version>4.0.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>struts2-jquery-integration-tests</artifactId>
+    <name>Struts 2 jQuery Integration Tests</name>
+    <packaging>war</packaging>
 
-  <scm>
-    <url>https://github.com/struts-community-plugins/struts2-jquery/struts2-jquery-integration-tests/</url>
-  </scm>
+    <scm>
+        <url>https://github.com/struts-community-plugins/struts2-jquery/struts2-jquery-integration-tests/</url>
+    </scm>
 
-  <properties>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <!-- plugins -->
-    <jetty-maven-plugin.version>9.4.0.v20161208</jetty-maven-plugin.version>
-    <maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
-    <!-- dependencies -->
-    <junit.version>4.12</junit.version>
-    <selenium.version>3.5.2</selenium.version>
-    <htmlunit-driver.version>2.27</htmlunit-driver.version>
-    <lombok.version>1.16.2</lombok.version>
-    <guava.version>23.0</guava.version>
-    <phantomjsdriver.version>1.4.3</phantomjsdriver.version>
-    <commons-codec.version>1.10</commons-codec.version>
-    <commons-io.version>2.5</commons-io.version>
-    <commons-lang.version>3.6</commons-lang.version>
-    <xml-apis.version>1.4.01</xml-apis.version>
+    <properties>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <!-- plugins -->
+        <jetty-maven-plugin.version>9.4.7.v20170914</jetty-maven-plugin.version>
+        <maven-failsafe-plugin.version>2.20.1</maven-failsafe-plugin.version>
+        <!-- dependencies -->
+        <junit.version>4.12</junit.version>
+        <selenium.version>3.6.0</selenium.version>
+        <htmlunit-driver.version>2.27</htmlunit-driver.version>
+        <lombok.version>1.16.18</lombok.version>
+        <guava.version>23.0</guava.version>
+        <phantomjsdriver.version>1.4.3</phantomjsdriver.version>
+        <commons-codec.version>1.10</commons-codec.version>
+        <commons-io.version>2.5</commons-io.version>
+        <commons-lang.version>3.6</commons-lang.version>
+        <xml-apis.version>1.4.01</xml-apis.version>
 
-    <failsafe.test.category>com.jgeppert.jquery.junit.category.HtmlUnitCategory</failsafe.test.category>
-    <failsafe.webdriver.name>HtmlUnit</failsafe.webdriver.name>
-  </properties>
+        <failsafe.test.category>com.jgeppert.jquery.junit.category.HtmlUnitCategory</failsafe.test.category>
+        <failsafe.webdriver.name>HtmlUnit</failsafe.webdriver.name>
+    </properties>
 
-  <profiles>
-    <profile>
-      <id>phantomjs</id>
-      <properties>
-        <failsafe.test.category>com.jgeppert.jquery.junit.category.PhantomJSCategory</failsafe.test.category>
-        <failsafe.webdriver.name>PhantomJS</failsafe.webdriver.name>
-      </properties>
-    </profile>
-  </profiles>
+    <profiles>
+        <profile>
+            <id>phantomjs</id>
+            <properties>
+                <failsafe.test.category>com.jgeppert.jquery.junit.category.PhantomJSCategory</failsafe.test.category>
+                <failsafe.webdriver.name>PhantomJS</failsafe.webdriver.name>
+            </properties>
+        </profile>
+    </profiles>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-maven-plugin</artifactId>
-      </plugin>
-    
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-      </plugin>
-    </plugins>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+            </plugin>
 
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>jetty-maven-plugin</artifactId>
-          <version>${jetty-maven-plugin.version}</version>
-          <configuration>
-            <stopKey>CTRL+C</stopKey>
-            <stopPort>8999</stopPort>
-            <scanIntervalSeconds>10</scanIntervalSeconds>
-          </configuration>
-          <executions>
-            <execution>
-              <id>start-jetty</id>
-              <phase>pre-integration-test</phase>
-              <goals>
-                <goal>start</goal>
-              </goals>
-              <configuration>
-                <scanIntervalSeconds>0</scanIntervalSeconds>
-                <daemon>true</daemon>
-              </configuration>
-            </execution>
-            <execution>
-              <id>stop-jetty</id>
-              <phase>post-integration-test</phase>
-              <goals>
-                <goal>stop</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
 
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${maven-failsafe-plugin.version}</version>
-          <configuration>
-            <forkCount>2</forkCount>
-            <reuseForks>true</reuseForks>
-            <groups>${failsafe.test.category}</groups>
-            <systemProperties>
-                <property>
-                    <name>webDriverName</name>
-                    <value>${failsafe.webdriver.name}</value>
-                </property>
-            </systemProperties>
-          </configuration>
-          <executions>
-            <execution>
-              <goals>
-                <goal>integration-test</goal>
-                <goal>verify</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-maven-plugin</artifactId>
+                    <version>${jetty-maven-plugin.version}</version>
+                    <configuration>
+                        <stopKey>CTRL+C</stopKey>
+                        <stopPort>8999</stopPort>
+                        <scanIntervalSeconds>10</scanIntervalSeconds>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>start-jetty</id>
+                            <phase>pre-integration-test</phase>
+                            <goals>
+                                <goal>start</goal>
+                            </goals>
+                            <configuration>
+                                <scanIntervalSeconds>0</scanIntervalSeconds>
+                                <daemon>true</daemon>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>stop-jetty</id>
+                            <phase>post-integration-test</phase>
+                            <goals>
+                                <goal>stop</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.struts</groupId>
-      <artifactId>struts2-convention-plugin</artifactId>
-    </dependency>
-            
-    <dependency>
-      <groupId>com.jgeppert.struts2.jquery</groupId>
-      <artifactId>struts2-jquery-plugin</artifactId>
-    </dependency>
-            
-    <dependency>
-      <groupId>com.jgeppert.struts2.jquery</groupId>
-      <artifactId>struts2-jquery-tree-plugin</artifactId>
-    </dependency>
-      
-    <dependency>
-      <groupId>org.apache.struts</groupId>
-      <artifactId>struts2-json-plugin</artifactId>
-    </dependency>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
+                    <configuration>
+                        <forkCount>2</forkCount>
+                        <reuseForks>true</reuseForks>
+                        <groups>${failsafe.test.category}</groups>
+                        <systemProperties>
+                            <property>
+                                <name>webDriverName</name>
+                                <value>${failsafe.webdriver.name}</value>
+                            </property>
+                        </systemProperties>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>selenium-server</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>htmlunit-driver</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-    </dependency>
-  </dependencies>
-
-  <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>org.apache.struts</groupId>
-        <artifactId>struts2-convention-plugin</artifactId>
-        <version>${struts2.version}</version>
-      </dependency>
+        <dependency>
+            <groupId>org.apache.struts</groupId>
+            <artifactId>struts2-convention-plugin</artifactId>
+        </dependency>
 
-      <dependency>
-        <groupId>com.jgeppert.struts2.jquery</groupId>
-        <artifactId>struts2-jquery-plugin</artifactId>
-        <version>${project.version}</version>
-      </dependency>
+        <dependency>
+            <groupId>com.jgeppert.struts2.jquery</groupId>
+            <artifactId>struts2-jquery-plugin</artifactId>
+        </dependency>
 
-      <dependency>
-        <groupId>com.jgeppert.struts2.jquery</groupId>
-        <artifactId>struts2-jquery-tree-plugin</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      
-      <dependency>
-        <groupId>org.apache.struts</groupId>
-        <artifactId>struts2-json-plugin</artifactId>
-        <version>${struts2.version}</version>
-      </dependency>
-      
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
+        <dependency>
+            <groupId>com.jgeppert.struts2.jquery</groupId>
+            <artifactId>struts2-jquery-tree-plugin</artifactId>
+        </dependency>
 
-      <dependency>
-        <groupId>org.seleniumhq.selenium</groupId>
-        <artifactId>selenium-server</artifactId>
-        <version>${selenium.version}</version>
-        <scope>test</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.apache.struts</groupId>
+            <artifactId>struts2-json-plugin</artifactId>
+        </dependency>
 
-      <dependency>
-        <groupId>org.seleniumhq.selenium</groupId>
-        <artifactId>htmlunit-driver</artifactId>
-        <version>${htmlunit-driver.version}</version>
-        <scope>test</scope>
-      </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
 
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
-        <scope>test</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-server</artifactId>
+        </dependency>
 
-      <dependency>
-        <groupId>com.codeborne</groupId>
-        <artifactId>phantomjsdriver</artifactId>
-        <version>${phantomjsdriver.version}</version>
-        <scope>test</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>htmlunit-driver</artifactId>
+        </dependency>
 
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>${commons-codec.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>${commons-io.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>${commons-lang.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.seleniumhq.selenium</groupId>
-        <artifactId>selenium-api</artifactId>
-        <version>${selenium.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.seleniumhq.selenium</groupId>
-        <artifactId>selenium-remote-driver</artifactId>
-        <version>${selenium.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.seleniumhq.selenium</groupId>
-        <artifactId>selenium-support</artifactId>
-        <version>${selenium.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>${xml-apis.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.projectlombok</groupId>
-        <artifactId>lombok</artifactId>
-        <version>${lombok.version}</version>
-        <scope>provided</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
     </dependencies>
-  </dependencyManagement>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.struts</groupId>
+                <artifactId>struts2-convention-plugin</artifactId>
+                <version>${struts2.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.jgeppert.struts2.jquery</groupId>
+                <artifactId>struts2-jquery-plugin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.jgeppert.struts2.jquery</groupId>
+                <artifactId>struts2-jquery-tree-plugin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.struts</groupId>
+                <artifactId>struts2-json-plugin</artifactId>
+                <version>${struts2.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-server</artifactId>
+                <version>${selenium.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>htmlunit-driver</artifactId>
+                <version>${htmlunit-driver.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.codeborne</groupId>
+                <artifactId>phantomjsdriver</artifactId>
+                <version>${phantomjsdriver.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-api</artifactId>
+                <version>${selenium.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-remote-driver</artifactId>
+                <version>${selenium.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-support</artifactId>
+                <version>${selenium.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>${xml-apis.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>
 

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -29,6 +29,7 @@
     <commons-codec.version>1.10</commons-codec.version>
     <commons-io.version>2.5</commons-io.version>
     <commons-lang.version>3.6</commons-lang.version>
+    <xml-apis.version>1.4.01</xml-apis.version>
 
     <failsafe.test.category>com.jgeppert.jquery.junit.category.HtmlUnitCategory</failsafe.test.category>
     <failsafe.webdriver.name>HtmlUnit</failsafe.webdriver.name>
@@ -258,6 +259,13 @@
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-support</artifactId>
         <version>${selenium.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+        <version>${xml-apis.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -96,7 +96,7 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${maven-failsafe-plugin.version}</version>
           <configuration>
-            <forkCount>4</forkCount>
+            <forkCount>2</forkCount>
             <reuseForks>true</reuseForks>
             <groups>${failsafe.test.category}</groups>
             <systemProperties>

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -26,6 +26,7 @@
     <lombok.version>1.16.2</lombok.version>
     <guava.version>23.0</guava.version>
     <phantomjsdriver.version>1.4.3</phantomjsdriver.version>
+    <commons-codec.version>1.10</commons-codec.version>
 
     <failsafe.test.category>com.jgeppert.jquery.junit.category.HtmlUnitCategory</failsafe.test.category>
     <failsafe.webdriver.name>HtmlUnit</failsafe.webdriver.name>
@@ -215,6 +216,13 @@
         <groupId>com.codeborne</groupId>
         <artifactId>phantomjsdriver</artifactId>
         <version>${phantomjsdriver.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>${commons-codec.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -25,6 +25,7 @@
     <htmlunit-driver.version>2.27</htmlunit-driver.version>
     <lombok.version>1.16.2</lombok.version>
     <guava.version>23.0</guava.version>
+    <phantomjsdriver.version>1.4.3</phantomjsdriver.version>
 
     <failsafe.test.category>com.jgeppert.jquery.junit.category.HtmlUnitCategory</failsafe.test.category>
     <failsafe.webdriver.name>HtmlUnit</failsafe.webdriver.name>
@@ -207,6 +208,13 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.codeborne</groupId>
+        <artifactId>phantomjsdriver</artifactId>
+        <version>${phantomjsdriver.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/struts2-jquery-integration-tests/src/main/java/com/jgeppert/jquery/actions/autocompleter/AutocompleterAction.java
+++ b/struts2-jquery-integration-tests/src/main/java/com/jgeppert/jquery/actions/autocompleter/AutocompleterAction.java
@@ -1,19 +1,29 @@
 package com.jgeppert.jquery.actions.autocompleter;
 
-import com.opensymphony.xwork2.ActionSupport;
-
 import java.util.Arrays;
 import java.util.List;
 
+import com.opensymphony.xwork2.ActionSupport;
+
 import lombok.Getter;
+import lombok.Setter;
 public class AutocompleterAction extends ActionSupport {
     @Getter
     private List<String> monthsList;
-    
+
+    @Setter
+    private boolean addError;
+
+    @Getter
+    @Setter
+    private boolean selectBox;
+
     @Override
     public String execute() {
         monthsList = Arrays.asList(new String[]{"January","February","March","April","May","June","July","August","September","October","November","December"});
-        
+        if (this.addError){
+            this.addFieldError("month","Some error message");
+        }
         return SUCCESS;
     }
 }

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/a/events.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/a/events.jsp
@@ -3,11 +3,11 @@
 
 <script type="text/javascript">
   jQuery.subscribe("ajaxlinkclick", function(event, data) {
-    alert("ajax link clicked");
+    document.getElementById("ajaxeventsdiv").appendChild(document.createTextNode("ajax link clicked"));
   }); 
 
   jQuery.subscribe("ajaxlinkcomplete", function(event, data) {
-    alert("ajax link complete");
+    document.getElementById("ajaxeventsdiv").appendChild(document.createTextNode("ajax link complete"));
   }); 
 </script>
 
@@ -18,3 +18,4 @@
   Run AJAX action
 </sj:a>
 
+<div id="ajaxeventsdiv"></div>

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayerrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayerrortopic.jsp
@@ -19,4 +19,8 @@
 <s:url namespace="/ajax" action="months" var="ajaxMonthsArrayUrl"/>
 <sj:autocompleter id="autocompleterMonths" name="month" href="a/wrong/url"
     onErrorTopics="autocompleteErrorTopic,autocompleteErrorTopic2" label="Select Month" loadMinimumCount="1" delay="50" />
+<<<<<<< Upstream, based on origin/release/4.0.3
 <div id="errorContainer"></div>
+=======
+<span id="errorContainer"></span>
+>>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayerrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayerrortopic.jsp
@@ -19,4 +19,4 @@
 <s:url namespace="/ajax" action="months" var="ajaxMonthsArrayUrl"/>
 <sj:autocompleter id="autocompleterMonths" name="month" href="a/wrong/url"
     onErrorTopics="autocompleteErrorTopic,autocompleteErrorTopic2" label="Select Month" loadMinimumCount="1" delay="50" />
-<span id="errorContainer"></span>
+<div id="errorContainer"></div>

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayerrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayerrortopic.jsp
@@ -1,0 +1,22 @@
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<script type="text/javascript">
+    var $errorContainer;
+    $(function(){
+       $errorContainer = $("#errorContainer");
+       $.subscribe("autocompleteErrorTopic",function(){
+           appendInErrorContainer("<p>topic1</p>");
+       });
+       $.subscribe("autocompleteErrorTopic2",function(){
+           appendInErrorContainer("<p>topic2</p>");
+       });
+    });
+
+    function appendInErrorContainer(content){
+        $errorContainer.append(content);
+    }
+</script>
+<s:url namespace="/ajax" action="months" var="ajaxMonthsArrayUrl"/>
+<sj:autocompleter id="autocompleterMonths" name="month" href="a/wrong/url"
+    onErrorTopics="autocompleteErrorTopic,autocompleteErrorTopic2" label="Select Month" loadMinimumCount="1" delay="50" />
+<span id="errorContainer"></span>

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayerrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayerrortopic.jsp
@@ -19,8 +19,4 @@
 <s:url namespace="/ajax" action="months" var="ajaxMonthsArrayUrl"/>
 <sj:autocompleter id="autocompleterMonths" name="month" href="a/wrong/url"
     onErrorTopics="autocompleteErrorTopic,autocompleteErrorTopic2" label="Select Month" loadMinimumCount="1" delay="50" />
-<<<<<<< Upstream, based on origin/release/4.0.3
-<div id="errorContainer"></div>
-=======
 <span id="errorContainer"></span>
->>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
@@ -19,5 +19,5 @@
 <s:url namespace="/ajax" action="monthsinobject" var="ajaxMonthsInObjectUrl"/>
 <sj:autocompleter id="autocompleterMonths" name="month" href="a/wrong/url"
     onErrorTopics="autocompleteErrorTopic,autocompleteErrorTopic2" label="Select Month" loadMinimumCount="1" delay="50" list="months" />
-<span id="errorContainer"></span>
+<div id="errorContainer"></div>
 

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
@@ -19,5 +19,9 @@
 <s:url namespace="/ajax" action="monthsinobject" var="ajaxMonthsInObjectUrl"/>
 <sj:autocompleter id="autocompleterMonths" name="month" href="a/wrong/url"
     onErrorTopics="autocompleteErrorTopic,autocompleteErrorTopic2" label="Select Month" loadMinimumCount="1" delay="50" list="months" />
+<<<<<<< Upstream, based on origin/release/4.0.3
 <div id="errorContainer"></div>
+=======
+<span id="errorContainer"></span>
+>>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
 

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
@@ -19,9 +19,5 @@
 <s:url namespace="/ajax" action="monthsinobject" var="ajaxMonthsInObjectUrl"/>
 <sj:autocompleter id="autocompleterMonths" name="month" href="a/wrong/url"
     onErrorTopics="autocompleteErrorTopic,autocompleteErrorTopic2" label="Select Month" loadMinimumCount="1" delay="50" list="months" />
-<<<<<<< Upstream, based on origin/release/4.0.3
-<div id="errorContainer"></div>
-=======
 <span id="errorContainer"></span>
->>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
 

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
@@ -1,0 +1,23 @@
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<script type="text/javascript">
+    var $errorContainer;
+    $(function(){
+       $errorContainer = $("#errorContainer");
+       $.subscribe("autocompleteErrorTopic",function(){
+           appendInErrorContainer("<p>topic1</p>");
+       });
+       $.subscribe("autocompleteErrorTopic2",function(){
+           appendInErrorContainer("<p>topic2</p>");
+       });
+    });
+
+    function appendInErrorContainer(content){
+        $errorContainer.append(content);
+    }
+</script>
+<s:url namespace="/ajax" action="monthsinobject" var="ajaxMonthsInObjectUrl"/>
+<sj:autocompleter id="autocompleterMonths" name="month" href="a/wrong/url"
+    onErrorTopics="autocompleteErrorTopic,autocompleteErrorTopic2" label="Select Month" loadMinimumCount="1" delay="50" list="months" />
+<span id="errorContainer"></span>
+

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxselectbox.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/ajaxselectbox.jsp
@@ -1,0 +1,11 @@
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<s:url namespace="/ajax" action="monthsinobject" var="ajaxMonthsInObjectUrl"/>
+<sj:select
+id="autocompleterMonths"
+name="month"
+list="monthObjects" listKey="number" listValue="month"
+href="%{ajaxMonthsInObjectUrl}" emptyOption="true"
+autocomplete="true" loadMinimumCount="1"
+cssClass="extra-class"
+/>

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/list.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/list.jsp
@@ -1,4 +1,10 @@
 <%@ taglib prefix="s" uri="/struts-tags" %>
 <%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
-<sj:autocompleter id="autocompleterMonths" cssClass="extra-class" cssErrorClass="error-class" name="month"
-    list="%{monthsList}" label="Select Month" selectBox="%{selectBox}" selectBoxIcon="%{selectBox}"/>
+<s:if test="%{selectBox }">
+    <sj:autocompleter id="autocompleterMonths" cssClass="extra-class" cssErrorClass="error-class" name="month"
+    	list="%{monthsList}" label="Select Month" selectBox="true" selectBoxIcon="true"/>
+</s:if>
+<s:else>
+	<sj:autocompleter id="autocompleterMonths" cssClass="extra-class" cssErrorClass="error-class" name="month"
+    list="%{monthsList}" label="Select Month" />
+</s:else>

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/list.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/list.jsp
@@ -1,5 +1,6 @@
 <%@ taglib prefix="s" uri="/struts-tags" %>
 <%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<<<<<<< Upstream, based on origin/release/4.0.3
 <s:if test="%{selectBox }">
     <sj:autocompleter id="autocompleterMonths" cssClass="extra-class" cssErrorClass="error-class" name="month"
     	list="%{monthsList}" label="Select Month" selectBox="true" selectBoxIcon="true"/>
@@ -8,3 +9,7 @@
 	<sj:autocompleter id="autocompleterMonths" cssClass="extra-class" cssErrorClass="error-class" name="month"
     list="%{monthsList}" label="Select Month" />
 </s:else>
+=======
+<sj:autocompleter id="autocompleterMonths" cssClass="extra-class" cssErrorClass="error-class" name="month"
+    list="%{monthsList}" label="Select Month" selectBox="%{selectBox}" selectBoxIcon="%{selectBox}"/>
+>>>>>>> a097000 #140 - Fixes missing JS when loadAtOnce=false #46 #36 - add Test cases for autocompleter in selectBox mode

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/list.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/list.jsp
@@ -1,5 +1,4 @@
 <%@ taglib prefix="s" uri="/struts-tags" %>
 <%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
-
-<sj:autocompleter id="autocompleterMonths" name="month" list="%{monthsList}" label="Select Month" />
-
+<sj:autocompleter id="autocompleterMonths" cssClass="extra-class" cssErrorClass="error-class" name="month"
+    list="%{monthsList}" label="Select Month" selectBox="%{selectBox}" selectBoxIcon="%{selectBox}"/>

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/list.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/autocompleter/list.jsp
@@ -1,15 +1,4 @@
 <%@ taglib prefix="s" uri="/struts-tags" %>
 <%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
-<<<<<<< Upstream, based on origin/release/4.0.3
-<s:if test="%{selectBox }">
-    <sj:autocompleter id="autocompleterMonths" cssClass="extra-class" cssErrorClass="error-class" name="month"
-    	list="%{monthsList}" label="Select Month" selectBox="true" selectBoxIcon="true"/>
-</s:if>
-<s:else>
-	<sj:autocompleter id="autocompleterMonths" cssClass="extra-class" cssErrorClass="error-class" name="month"
-    list="%{monthsList}" label="Select Month" />
-</s:else>
-=======
-<sj:autocompleter id="autocompleterMonths" cssClass="extra-class" cssErrorClass="error-class" name="month"
-    list="%{monthsList}" label="Select Month" selectBox="%{selectBox}" selectBoxIcon="%{selectBox}"/>
->>>>>>> a097000 #140 - Fixes missing JS when loadAtOnce=false #46 #36 - add Test cases for autocompleter in selectBox mode
+
+<sj:autocompleter id="autocompleterMonths" name="month" list="%{monthsList}" label="Select Month" />

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/submit/events.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/includes/submit/events.jsp
@@ -3,11 +3,11 @@
 
 <script type="text/javascript">
   jQuery.subscribe("beforeformsubmit", function(event, data) {
-    alert("ajax submit clicked");
+    document.getElementById("ajaxeventsdiv").appendChild(document.createTextNode("ajax submit clicked"));
   }); 
 
   jQuery.subscribe("formsubmitcomplete", function(event, data) {
-    alert("ajax submit complete");
+    document.getElementById("ajaxeventsdiv").appendChild(document.createTextNode("ajax submit complete"));
   }); 
 </script>
 
@@ -18,4 +18,4 @@
   <s:textfield id="echo" name="echo" value="something to echo"/>
   <sj:submit id="formsubmit" onBeforeTopics="beforeformsubmit" onCompleteTopics="formsubmitcomplete" targets="formResult" value="Submit Form" button="true"/>
 </s:form>
-
+<div id="ajaxeventsdiv"></div>

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/loadatonce/autocompleter/ajaxarrayerrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/loadatonce/autocompleter/ajaxarrayerrortopic.jsp
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<html lang="en">
+  <head>
+    <sj:head loadAtOnce="true"/>
+  </head>
+  <body>
+    <s:include value="/WEB-INF/content/includes/autocompleter/ajaxarrayerrortopic.jsp"/>
+  </body>
+</html>
+

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/loadatonce/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/loadatonce/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<html lang="en">
+  <head>
+    <sj:head loadAtOnce="true"/>
+  </head>
+  <body>
+    <s:include value="/WEB-INF/content/includes/autocompleter/ajaxarrayinsideobjecterrortopic.jsp"/>
+  </body>
+</html>
+

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/loadatonce/autocompleter/ajaxselectbox.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/loadatonce/autocompleter/ajaxselectbox.jsp
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<html lang="en">
+  <head>
+    <sj:head loadAtOnce="true"/>
+  </head>
+  <body>
+    <s:include value="/WEB-INF/content/includes/autocompleter/ajaxselectbox.jsp"/>
+  </body>
+</html>
+

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/loadfromgoogle/autocompleter/ajaxarrayerrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/loadfromgoogle/autocompleter/ajaxarrayerrortopic.jsp
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<html lang="en">
+  <head>
+    <sj:head loadFromGoogle="true"/>
+  </head>
+  <body>
+    <s:include value="/WEB-INF/content/includes/autocompleter/ajaxarrayerrortopic.jsp"/>
+  </body>
+</html>
+

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/loadfromgoogle/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/loadfromgoogle/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<html lang="en">
+  <head>
+    <sj:head loadFromGoogle="true"/>
+  </head>
+  <body>
+    <s:include value="/WEB-INF/content/includes/autocompleter/ajaxarrayinsideobjecterrortopic.jsp"/>
+  </body>
+</html>
+

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/loadfromgoogle/autocompleter/ajaxselectbox.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/loadfromgoogle/autocompleter/ajaxselectbox.jsp
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<html lang="en">
+  <head>
+    <sj:head loadFromGoogle="true"/>
+  </head>
+  <body>
+    <s:include value="/WEB-INF/content/includes/autocompleter/ajaxselectbox.jsp"/>
+  </body>
+</html>
+

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/regular/autocompleter/ajaxarrayerrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/regular/autocompleter/ajaxarrayerrortopic.jsp
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<html lang="en">
+  <head>
+    <sj:head/>
+  </head>
+  <body>
+    <s:include value="/WEB-INF/content/includes/autocompleter/ajaxarrayerrortopic.jsp"/>
+  </body>
+</html>
+

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/regular/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/regular/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<html lang="en">
+  <head>
+    <sj:head/>
+  </head>
+  <body>
+    <s:include value="/WEB-INF/content/includes/autocompleter/ajaxarrayinsideobjecterrortopic.jsp"/>
+  </body>
+</html>
+

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/regular/autocompleter/ajaxselectbox.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/regular/autocompleter/ajaxselectbox.jsp
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<html lang="en">
+  <head>
+    <sj:head/>
+  </head>
+  <body>
+    <s:include value="/WEB-INF/content/includes/autocompleter/ajaxselectbox.jsp"/>
+  </body>
+</html>
+

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/uncompressed/autocompleter/ajaxarrayerrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/uncompressed/autocompleter/ajaxarrayerrortopic.jsp
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<html lang="en">
+  <head>
+    <sj:head compressed="false"/>
+  </head>
+  <body>
+    <s:include value="/WEB-INF/content/includes/autocompleter/ajaxarrayerrortopic.jsp"/>
+  </body>
+</html>
+

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/uncompressed/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/uncompressed/autocompleter/ajaxarrayinsideobjecterrortopic.jsp
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<html lang="en">
+  <head>
+    <sj:head compressed="false"/>
+  </head>
+  <body>
+    <s:include value="/WEB-INF/content/includes/autocompleter/ajaxarrayinsideobjecterrortopic.jsp"/>
+  </body>
+</html>
+

--- a/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/uncompressed/autocompleter/ajaxselectbox.jsp
+++ b/struts2-jquery-integration-tests/src/main/webapp/WEB-INF/content/uncompressed/autocompleter/ajaxselectbox.jsp
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<%@ taglib prefix="sj" uri="/struts-jquery-tags" %>
+<html lang="en">
+  <head>
+    <sj:head compressed="false"/>
+  </head>
+  <body>
+    <s:include value="/WEB-INF/content/includes/autocompleter/ajaxselectbox.jsp"/>
+  </body>
+</html>
+

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/a/ATagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/a/ATagIT.java
@@ -17,7 +17,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WebDriver;
@@ -25,7 +24,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 @RunWith(Parameterized.class)
-@Category({HtmlUnitCategory.class})
+@Category({HtmlUnitCategory.class, PhantomJSCategory.class})
 public class ATagIT {
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
@@ -57,7 +56,6 @@ public class ATagIT {
     }
 
     @Test
-    @Category({PhantomJSCategory.class})
     public void testSimpleAjaxPageLink() {
         WebDriverWait wait = new WebDriverWait(driver, 30);
 
@@ -74,7 +72,6 @@ public class ATagIT {
     }
     
     @Test
-    @Category({PhantomJSCategory.class})
     public void testMultipleTargets() {
         WebDriverWait wait = new WebDriverWait(driver, 30);
 
@@ -95,7 +92,6 @@ public class ATagIT {
     }
 
     @Test
-    @Category({PhantomJSCategory.class})
     public void testFormSubmit() {
         WebDriverWait wait = new WebDriverWait(driver, 30);
 
@@ -136,26 +132,13 @@ public class ATagIT {
         ajaxLink.click();
 
         wait.until(JQUERY_IDLE);
-        wait.until(ExpectedConditions.alertIsPresent());
-        Alert alert = driver.switchTo().alert();
-	
-        Assert.assertEquals("ajax link clicked", alert.getText());
 
-        alert.accept();
-
-        wait.until(JQUERY_IDLE);
-        wait.until(ExpectedConditions.alertIsPresent());
-        alert = driver.switchTo().alert();
-
-        Assert.assertEquals("ajax link complete", alert.getText());
-
-        alert.accept();
-	
+	WebElement ajaxeventsdiv = driver.findElement(By.id("ajaxeventsdiv"));
+        Assert.assertEquals("ajax link clickedajax link complete", ajaxeventsdiv.getText());
         Assert.assertEquals("This is simple text from an ajax call.", result.getText());
     }
 
     @Test
-    @Category({PhantomJSCategory.class})
     public void testJsonResult() {
         WebDriverWait wait = new WebDriverWait(driver, 30);
 

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterSelectBoxTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterSelectBoxTagIT.java
@@ -1,0 +1,161 @@
+package com.jgeppert.jquery.autocompleter;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import com.jgeppert.jquery.junit.category.PhantomJSCategory;
+import com.jgeppert.jquery.selenium.JQueryIdleCondition;
+import com.jgeppert.jquery.selenium.JQueryNoAnimations;
+import com.jgeppert.jquery.selenium.WebDriverFactory;
+
+/**
+ *
+ * Test cases for autocompleter in selectBox mode.
+ *
+ * TODO See if how we can make it working with HtmlUnit too.
+ *
+ */
+@RunWith(Parameterized.class)
+@Category({PhantomJSCategory.class})
+public class AutocompleterSelectBoxTagIT {
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                 { "http://localhost:8080/regular" },
+                 { "http://localhost:8080/uncompressed" },
+                 { "http://localhost:8080/loadatonce" },
+                 { "http://localhost:8080/loadfromgoogle" }
+           });
+    }
+
+    private static final JQueryIdleCondition JQUERY_IDLE = new JQueryIdleCondition();
+    private static final JQueryNoAnimations JQUERY_NO_ANIMATIONS = new JQueryNoAnimations();
+
+    private String baseUrl;
+    private WebDriver driver;
+
+    public AutocompleterSelectBoxTagIT(final String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    @Before
+    public void before() {
+        driver = WebDriverFactory.getWebDriver();
+    }
+
+    @After
+    public void after() {
+        driver.quit();
+    }
+
+    @Test
+    public void testListDataWithSelectbox() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
+        driver.get(baseUrl + "/autocompleter/list.action?selectBox=true");
+
+        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+        WebElement autocompleteInputWidget = wait.until(ExpectedConditions
+                .presenceOfAllElementsLocatedBy(By.className("s2j-combobox-input"))).get(0);
+        WebElement autocompleteSelectButton = driver.findElement(By.className("s2j-combobox-toggle"));
+        Actions builder = new Actions(driver);
+
+        builder.moveToElement(autocompleteInputWidget).click().perform();
+        Assert.assertEquals(0, driver.findElements(By.tagName("li")).size());
+
+        autocompleteSelectButton.click();
+
+        Assert.assertTrue( driver.findElement(By.cssSelector("ul.ui-autocomplete")).isDisplayed());
+        Assert.assertEquals(12, driver.findElements(By.tagName("li")).size());
+
+        autocompleteSelectButton.click();
+
+        Assert.assertFalse( driver.findElement(By.cssSelector("ul.ui-autocomplete")).isDisplayed());
+
+        autocompleteInputWidget.sendKeys("j");
+        Thread.sleep(1000);
+        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+
+        autocompleteInputWidget.sendKeys("u");
+        Thread.sleep(1000);
+        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+
+        WebElement li = driver.findElements(By.tagName("li")).get(0);
+        String expected = li.getText();
+
+        builder.moveToElement(li).click().perform();
+        Assert.assertFalse( driver.findElement(By.cssSelector("ul.ui-autocomplete")).isDisplayed());
+
+        Assert.assertEquals(expected, autocompleteInput.getAttribute("value"));
+
+      //verify #46 - handling of cssClass attribute
+        Assert.assertThat(autocompleteInputWidget.getAttribute("class"), containsString("extra-class"));
+    }
+
+    @Test
+    public void testListDataWithCssErrorClass() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
+        this.testListDataWithSelectbox();
+        driver.get(baseUrl + "/autocompleter/list.action?selectBox=true&addError=true");
+
+        WebElement autocompleteInputWidget = wait.until(ExpectedConditions
+                .presenceOfAllElementsLocatedBy(By.className("s2j-combobox-input"))).get(0);
+        WebElement autocompleteSelectButton = driver.findElement(By.className("s2j-combobox-toggle"));
+
+        //verify #46 - handling of cssErrorClass attribute
+        Assert.assertThat(autocompleteInputWidget.getAttribute("class"), containsString("error-class"));
+    }
+
+    @Test
+    public void testAjaxSelectbox() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
+        driver.get(baseUrl + "/autocompleter/list.action?selectBox=true");
+
+        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+        WebElement autocompleteInputWidget = wait.until(ExpectedConditions
+                .presenceOfAllElementsLocatedBy(By.className("s2j-combobox-input"))).get(0);
+        Actions builder = new Actions(driver);
+
+        builder.moveToElement(autocompleteInputWidget).click().perform();
+        Assert.assertEquals(0, driver.findElements(By.tagName("li")).size());
+
+        Assert.assertFalse( driver.findElement(By.cssSelector("ul.ui-autocomplete")).isDisplayed());
+
+        autocompleteInputWidget.sendKeys("j");
+        Thread.sleep(1000);
+        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+
+        autocompleteInputWidget.sendKeys("u");
+        Thread.sleep(1000);
+        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+
+        WebElement li = driver.findElements(By.tagName("li")).get(0);
+        String expected = li.getText();
+
+        builder.moveToElement(li).click().perform();
+        Assert.assertFalse( driver.findElement(By.cssSelector("ul.ui-autocomplete")).isDisplayed());
+
+        Assert.assertEquals(expected, autocompleteInput.getAttribute("value"));
+
+      //verify #46 - handling of cssClass attribute
+        Assert.assertThat(autocompleteInputWidget.getAttribute("class"), containsString("extra-class"));
+    }
+
+
+}
+

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
@@ -17,6 +17,7 @@ import org.junit.runners.Parameterized;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import com.jgeppert.jquery.junit.category.HtmlUnitCategory;
@@ -77,7 +78,7 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+        Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
 
     @Test
@@ -99,7 +100,7 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+        Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
 
     @Test
@@ -121,7 +122,7 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+        Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
 
     @Test
@@ -143,7 +144,7 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+        Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
     }
 
     @Test
@@ -165,58 +166,56 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+        Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
     }
 
-	@Test
-	public void testAjaxArrayErrorTopic() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
+    @Test
+    public void testAjaxArrayErrorTopic() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
 
-		driver.get(baseUrl + "/autocompleter/ajaxarrayerrortopic.action");
+        driver.get(baseUrl + "/autocompleter/ajaxarrayerrortopic.action");
 
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
-		WebElement errorContainer = driver.findElement(By.id("errorContainer"));
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        WebElement errorContainer = driver.findElement(By.id("errorContainer"));
 
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-		Assert.assertEquals(0, driver.findElements(By.tagName("li")).size());
+        autocompleteInputWidget.sendKeys("j");
+        wait.until(ExpectedConditions.presenceOfNestedElementLocatedBy(errorContainer, By.tagName("p")));
+        Assert.assertEquals(0, driver.findElements(By.tagName("li")).size());
 
-		List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
-		Assert.assertEquals(2, ps.size());
+        List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
+        Assert.assertEquals(2, ps.size());
 
-		List<String> result = new ArrayList<>();
-		for (WebElement p : ps) {
-			result.add(p.getText());
-		}
+        List<String> result = new ArrayList<>();
+        for (WebElement p : ps) {
+            result.add(p.getText());
+        }
 
-		Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
+        Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
 
-	}
+    }
 
-	@Test
-	public void testAjaxArrayInsideObjectErrorTopic() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
+    @Test
+    public void testAjaxArrayInsideObjectErrorTopic() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
 
-		driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobjecterrortopic.action");
+        driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobjecterrortopic.action");
 
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
-		WebElement errorContainer = driver.findElement(By.id("errorContainer"));
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        WebElement errorContainer = driver.findElement(By.id("errorContainer"));
 
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
+        autocompleteInputWidget.sendKeys("j");
+        wait.until(ExpectedConditions.presenceOfNestedElementLocatedBy(errorContainer, By.tagName("p")));
 
-		List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
-		Assert.assertEquals(2, ps.size());
+        List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
+        Assert.assertEquals(2, ps.size());
 
-		List<String> result = new ArrayList<>();
-		for (WebElement p : ps) {
-			result.add(p.getText());
-		}
+        List<String> result = new ArrayList<>();
+        for (WebElement p : ps) {
+            result.add(p.getText());
+        }
 
-		Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
+        Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
 
-	}
+    }
 }
 

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
@@ -1,6 +1,7 @@
 package com.jgeppert.jquery.autocompleter;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.contains;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,6 +80,21 @@ public class AutocompleterTagIT {
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
         Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+
+        //verify #46 - handling of cssClass attribute
+        Assert.assertThat(autocompleteInputWidget.getAttribute("class"), containsString("extra-class"));
+    }
+
+    @Test
+    public void testListDataWithCssErrorClass() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
+        this.testListData();
+        driver.get(baseUrl + "/autocompleter/list.action?addError=true");
+
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+
+        //verify #46 - handling of cssErrorClass attribute
+        Assert.assertThat(autocompleteInputWidget.getAttribute("class"), containsString("error-class"));
     }
 
     @Test
@@ -169,6 +185,13 @@ public class AutocompleterTagIT {
         Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
     }
 
+
+    /**
+     * Issue #36 - verify that errorTopics are fired if AJAX request fail.
+     * Autocompleter waiting for a JSON array
+     *
+     * @throws InterruptedException
+     */
     @Test
     public void testAjaxArrayErrorTopic() throws InterruptedException {
         WebDriverWait wait = new WebDriverWait(driver, 30);
@@ -190,10 +213,16 @@ public class AutocompleterTagIT {
             result.add(p.getText());
         }
 
-        Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
+        Assert.assertThat(result, contains("topic1", "topic2"));
 
     }
 
+    /**
+     * Issue #36 - verify that errorTopics are fired if AJAX request fail.
+     * Autocompleter waiting for a JSON array inside an object
+     *
+     * @throws InterruptedException
+     */
     @Test
     public void testAjaxArrayInsideObjectErrorTopic() throws InterruptedException {
         WebDriverWait wait = new WebDriverWait(driver, 30);
@@ -214,7 +243,7 @@ public class AutocompleterTagIT {
             result.add(p.getText());
         }
 
-        Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
+        Assert.assertThat(result, contains("topic1", "topic2"));
 
     }
 }

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
@@ -17,6 +17,14 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+<<<<<<< Upstream, based on origin/release/4.0.3
+=======
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+>>>>>>> 7ccdda6 trying to use WebDriverWait instead of Thread.sleep
 
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
@@ -77,7 +85,7 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+        Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
 
     @Test
@@ -99,7 +107,7 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+        Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
 
     @Test
@@ -121,7 +129,7 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+        Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
 
     @Test
@@ -143,7 +151,7 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+        Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
     }
 
     @Test
@@ -165,6 +173,58 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+        Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
     }
+<<<<<<< Upstream, based on origin/release/4.0.3
+=======
+
+    @Test
+    public void testAjaxArrayErrorTopic() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
+
+        driver.get(baseUrl + "/autocompleter/ajaxarrayerrortopic.action");
+
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        WebElement errorContainer = driver.findElement(By.id("errorContainer"));
+
+        autocompleteInputWidget.sendKeys("j");
+        wait.until(ExpectedConditions.presenceOfNestedElementLocatedBy(errorContainer, By.tagName("p")));
+        Assert.assertEquals(0, driver.findElements(By.tagName("li")).size());
+
+        List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
+        Assert.assertEquals(2, ps.size());
+
+        List<String> result = new ArrayList<>();
+        for (WebElement p : ps) {
+            result.add(p.getText());
+        }
+
+        Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
+
+    }
+
+    @Test
+    public void testAjaxArrayInsideObjectErrorTopic() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
+
+        driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobjecterrortopic.action");
+
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        WebElement errorContainer = driver.findElement(By.id("errorContainer"));
+
+        autocompleteInputWidget.sendKeys("j");
+        wait.until(ExpectedConditions.presenceOfNestedElementLocatedBy(errorContainer, By.tagName("p")));
+
+        List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
+        Assert.assertEquals(2, ps.size());
+
+        List<String> result = new ArrayList<>();
+        for (WebElement p : ps) {
+            result.add(p.getText());
+        }
+
+        Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
+
+    }
+>>>>>>> 7ccdda6 trying to use WebDriverWait instead of Thread.sleep
 }

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
@@ -1,11 +1,8 @@
 package com.jgeppert.jquery.autocompleter;
 
-import com.jgeppert.jquery.selenium.JQueryIdleCondition;
-import com.jgeppert.jquery.selenium.JQueryNoAnimations;
-import com.jgeppert.jquery.selenium.WebDriverFactory;
-import com.jgeppert.jquery.junit.category.HtmlUnitCategory;
-import com.jgeppert.jquery.junit.category.PhantomJSCategory;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -17,155 +14,205 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import com.jgeppert.jquery.junit.category.HtmlUnitCategory;
+import com.jgeppert.jquery.junit.category.PhantomJSCategory;
+import com.jgeppert.jquery.selenium.JQueryIdleCondition;
+import com.jgeppert.jquery.selenium.JQueryNoAnimations;
+import com.jgeppert.jquery.selenium.WebDriverFactory;
+
 @RunWith(Parameterized.class)
-@Category({HtmlUnitCategory.class, PhantomJSCategory.class})
+@Category({ HtmlUnitCategory.class, PhantomJSCategory.class })
 public class AutocompleterTagIT {
-    @Parameterized.Parameters
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-                 { "http://localhost:8080/regular" }, 
-                 { "http://localhost:8080/uncompressed" },
-                 { "http://localhost:8080/loadatonce" }, 
-                 { "http://localhost:8080/loadfromgoogle" }  
-           });
-    }
-    
-    private static final JQueryIdleCondition JQUERY_IDLE = new JQueryIdleCondition();
-    private static final JQueryNoAnimations JQUERY_NO_ANIMATIONS = new JQueryNoAnimations();
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() {
+		return Arrays
+		        .asList(new Object[][] { { "http://localhost:8080/regular" }, { "http://localhost:8080/uncompressed" },
+		                { "http://localhost:8080/loadatonce" }, { "http://localhost:8080/loadfromgoogle" } });
+	}
 
-    private String baseUrl;        
-    private WebDriver driver;        
+	private static final JQueryIdleCondition JQUERY_IDLE = new JQueryIdleCondition();
+	private static final JQueryNoAnimations JQUERY_NO_ANIMATIONS = new JQueryNoAnimations();
 
-    public AutocompleterTagIT(final String baseUrl) {
-        this.baseUrl = baseUrl;
-    }
+	private String baseUrl;
+	private WebDriver driver;
 
-    @Before
-    public void before() {
-        driver = WebDriverFactory.getWebDriver();
-    }
+	public AutocompleterTagIT(final String baseUrl) {
+		this.baseUrl = baseUrl;
+	}
 
-    @After
-    public void after() {
-        driver.quit();
-    }
+	@Before
+	public void before() {
+		driver = WebDriverFactory.getWebDriver();
+	}
 
-    @Test
-    public void testListData() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
+	@After
+	public void after() {
+		driver.quit();
+	}
 
-        driver.get(baseUrl + "/autocompleter/list.action");
+	@Test
+	public void testListData() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
 
-        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		driver.get(baseUrl + "/autocompleter/list.action");
 
-        autocompleteInputWidget.sendKeys("j");
-        Thread.sleep(1000);
-        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-        autocompleteInputWidget.sendKeys("u");
-        Thread.sleep(1000);
-        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-        driver.findElements(By.tagName("li")).get(0).click();
-        Thread.sleep(1000);
-	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
-    }
+		autocompleteInputWidget.sendKeys("u");
+		Thread.sleep(1000);
+		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-    @Test
-    public void testAjaxArray() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
+		driver.findElements(By.tagName("li")).get(0).click();
+		Thread.sleep(1000);
+		Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+	}
 
-        driver.get(baseUrl + "/autocompleter/ajaxarray.action");
+	@Test
+	public void testAjaxArray() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
 
-        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		driver.get(baseUrl + "/autocompleter/ajaxarray.action");
 
-        autocompleteInputWidget.sendKeys("j");
-        Thread.sleep(1000);
-        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-        autocompleteInputWidget.sendKeys("u");
-        Thread.sleep(1000);
-        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-        driver.findElements(By.tagName("li")).get(0).click();
-        Thread.sleep(1000);
-	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
-    }
+		autocompleteInputWidget.sendKeys("u");
+		Thread.sleep(1000);
+		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-    @Test
-    public void testAjaxArrayInsideObject() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
+		driver.findElements(By.tagName("li")).get(0).click();
+		Thread.sleep(1000);
+		Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+	}
 
-        driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobject.action");
+	@Test
+	public void testAjaxArrayInsideObject() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
 
-        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobject.action");
 
-        autocompleteInputWidget.sendKeys("j");
-        Thread.sleep(1000);
-        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-        autocompleteInputWidget.sendKeys("u");
-        Thread.sleep(1000);
-        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-        driver.findElements(By.tagName("li")).get(0).click();
-        Thread.sleep(1000);
-	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
-    }
+		autocompleteInputWidget.sendKeys("u");
+		Thread.sleep(1000);
+		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-    @Test
-    public void testAjaxMapInsideObject() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
+		driver.findElements(By.tagName("li")).get(0).click();
+		Thread.sleep(1000);
+		Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+	}
 
-        driver.get(baseUrl + "/autocompleter/ajaxmapinsideobject.action");
+	@Test
+	public void testAjaxMapInsideObject() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
 
-        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		driver.get(baseUrl + "/autocompleter/ajaxmapinsideobject.action");
 
-        autocompleteInputWidget.sendKeys("j");
-        Thread.sleep(1000);
-        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-        autocompleteInputWidget.sendKeys("u");
-        Thread.sleep(1000);
-        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-        driver.findElements(By.tagName("li")).get(0).click();
-        Thread.sleep(1000);
-	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
-    }
+		autocompleteInputWidget.sendKeys("u");
+		Thread.sleep(1000);
+		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-    @Test
-    public void testAjaxObjectsInsideObject() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
+		driver.findElements(By.tagName("li")).get(0).click();
+		Thread.sleep(1000);
+		Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+	}
 
-        driver.get(baseUrl + "/autocompleter/ajaxobjectsinsideobject.action");
+	@Test
+	public void testAjaxObjectsInsideObject() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
 
-        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		driver.get(baseUrl + "/autocompleter/ajaxobjectsinsideobject.action");
 
-        autocompleteInputWidget.sendKeys("j");
-        Thread.sleep(1000);
-        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-        autocompleteInputWidget.sendKeys("u");
-        Thread.sleep(1000);
-        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-        driver.findElements(By.tagName("li")).get(0).click();
-        Thread.sleep(1000);
-	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
-    }
+		autocompleteInputWidget.sendKeys("u");
+		Thread.sleep(1000);
+		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+
+		driver.findElements(By.tagName("li")).get(0).click();
+		Thread.sleep(1000);
+		Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+	}
+
+	@Test
+	public void testAjaxArrayErrorTopic() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
+
+		driver.get(baseUrl + "/autocompleter/ajaxarrayerrortopic.action");
+
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		WebElement errorContainer = driver.findElement(By.id("errorContainer"));
+
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+		Assert.assertEquals(0, driver.findElements(By.tagName("li")).size());
+
+		List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
+		Assert.assertEquals(2, ps.size());
+
+		List<String> result = new ArrayList<>();
+		for (WebElement p : ps) {
+			result.add(p.getText());
+		}
+
+		Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
+
+	}
+
+	@Test
+	public void testAjaxArrayInsideObjectErrorTopic() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
+
+		driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobjecterrortopic.action");
+
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		WebElement errorContainer = driver.findElement(By.id("errorContainer"));
+
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+
+		List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
+		Assert.assertEquals(2, ps.size());
+
+		List<String> result = new ArrayList<>();
+		for (WebElement p : ps) {
+			result.add(p.getText());
+		}
+
+		Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
+
+	}
 }
-

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
@@ -1,8 +1,11 @@
 package com.jgeppert.jquery.autocompleter;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import com.jgeppert.jquery.selenium.JQueryIdleCondition;
+import com.jgeppert.jquery.selenium.JQueryNoAnimations;
+import com.jgeppert.jquery.selenium.WebDriverFactory;
+import com.jgeppert.jquery.junit.category.HtmlUnitCategory;
+import com.jgeppert.jquery.junit.category.PhantomJSCategory;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -14,205 +17,155 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import com.jgeppert.jquery.junit.category.HtmlUnitCategory;
-import com.jgeppert.jquery.junit.category.PhantomJSCategory;
-import com.jgeppert.jquery.selenium.JQueryIdleCondition;
-import com.jgeppert.jquery.selenium.JQueryNoAnimations;
-import com.jgeppert.jquery.selenium.WebDriverFactory;
-
 @RunWith(Parameterized.class)
-@Category({ HtmlUnitCategory.class, PhantomJSCategory.class })
+@Category({HtmlUnitCategory.class, PhantomJSCategory.class})
 public class AutocompleterTagIT {
-	@Parameterized.Parameters
-	public static Collection<Object[]> data() {
-		return Arrays
-		        .asList(new Object[][] { { "http://localhost:8080/regular" }, { "http://localhost:8080/uncompressed" },
-		                { "http://localhost:8080/loadatonce" }, { "http://localhost:8080/loadfromgoogle" } });
-	}
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                 { "http://localhost:8080/regular" }, 
+                 { "http://localhost:8080/uncompressed" },
+                 { "http://localhost:8080/loadatonce" }, 
+                 { "http://localhost:8080/loadfromgoogle" }  
+           });
+    }
+    
+    private static final JQueryIdleCondition JQUERY_IDLE = new JQueryIdleCondition();
+    private static final JQueryNoAnimations JQUERY_NO_ANIMATIONS = new JQueryNoAnimations();
 
-	private static final JQueryIdleCondition JQUERY_IDLE = new JQueryIdleCondition();
-	private static final JQueryNoAnimations JQUERY_NO_ANIMATIONS = new JQueryNoAnimations();
+    private String baseUrl;        
+    private WebDriver driver;        
 
-	private String baseUrl;
-	private WebDriver driver;
+    public AutocompleterTagIT(final String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
 
-	public AutocompleterTagIT(final String baseUrl) {
-		this.baseUrl = baseUrl;
-	}
+    @Before
+    public void before() {
+        driver = WebDriverFactory.getWebDriver();
+    }
 
-	@Before
-	public void before() {
-		driver = WebDriverFactory.getWebDriver();
-	}
+    @After
+    public void after() {
+        driver.quit();
+    }
 
-	@After
-	public void after() {
-		driver.quit();
-	}
+    @Test
+    public void testListData() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
 
-	@Test
-	public void testListData() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
+        driver.get(baseUrl + "/autocompleter/list.action");
 
-		driver.get(baseUrl + "/autocompleter/list.action");
+        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        autocompleteInputWidget.sendKeys("j");
+        Thread.sleep(1000);
+        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+        autocompleteInputWidget.sendKeys("u");
+        Thread.sleep(1000);
+        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("u");
-		Thread.sleep(1000);
-		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+        driver.findElements(By.tagName("li")).get(0).click();
+        Thread.sleep(1000);
+	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+    }
 
-		driver.findElements(By.tagName("li")).get(0).click();
-		Thread.sleep(1000);
-		Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
-	}
+    @Test
+    public void testAjaxArray() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
 
-	@Test
-	public void testAjaxArray() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
+        driver.get(baseUrl + "/autocompleter/ajaxarray.action");
 
-		driver.get(baseUrl + "/autocompleter/ajaxarray.action");
+        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        autocompleteInputWidget.sendKeys("j");
+        Thread.sleep(1000);
+        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+        autocompleteInputWidget.sendKeys("u");
+        Thread.sleep(1000);
+        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("u");
-		Thread.sleep(1000);
-		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+        driver.findElements(By.tagName("li")).get(0).click();
+        Thread.sleep(1000);
+	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+    }
 
-		driver.findElements(By.tagName("li")).get(0).click();
-		Thread.sleep(1000);
-		Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
-	}
+    @Test
+    public void testAjaxArrayInsideObject() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
 
-	@Test
-	public void testAjaxArrayInsideObject() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
+        driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobject.action");
 
-		driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobject.action");
+        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        autocompleteInputWidget.sendKeys("j");
+        Thread.sleep(1000);
+        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+        autocompleteInputWidget.sendKeys("u");
+        Thread.sleep(1000);
+        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("u");
-		Thread.sleep(1000);
-		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+        driver.findElements(By.tagName("li")).get(0).click();
+        Thread.sleep(1000);
+	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+    }
 
-		driver.findElements(By.tagName("li")).get(0).click();
-		Thread.sleep(1000);
-		Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
-	}
+    @Test
+    public void testAjaxMapInsideObject() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
 
-	@Test
-	public void testAjaxMapInsideObject() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
+        driver.get(baseUrl + "/autocompleter/ajaxmapinsideobject.action");
 
-		driver.get(baseUrl + "/autocompleter/ajaxmapinsideobject.action");
+        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        autocompleteInputWidget.sendKeys("j");
+        Thread.sleep(1000);
+        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+        autocompleteInputWidget.sendKeys("u");
+        Thread.sleep(1000);
+        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("u");
-		Thread.sleep(1000);
-		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+        driver.findElements(By.tagName("li")).get(0).click();
+        Thread.sleep(1000);
+	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+    }
 
-		driver.findElements(By.tagName("li")).get(0).click();
-		Thread.sleep(1000);
-		Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
-	}
+    @Test
+    public void testAjaxObjectsInsideObject() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
 
-	@Test
-	public void testAjaxObjectsInsideObject() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
+        driver.get(baseUrl + "/autocompleter/ajaxobjectsinsideobject.action");
 
-		driver.get(baseUrl + "/autocompleter/ajaxobjectsinsideobject.action");
+        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        autocompleteInputWidget.sendKeys("j");
+        Thread.sleep(1000);
+        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+        autocompleteInputWidget.sendKeys("u");
+        Thread.sleep(1000);
+        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("u");
-		Thread.sleep(1000);
-		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
-
-		driver.findElements(By.tagName("li")).get(0).click();
-		Thread.sleep(1000);
-		Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
-	}
-
-	@Test
-	public void testAjaxArrayErrorTopic() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
-
-		driver.get(baseUrl + "/autocompleter/ajaxarrayerrortopic.action");
-
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
-		WebElement errorContainer = driver.findElement(By.id("errorContainer"));
-
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-		Assert.assertEquals(0, driver.findElements(By.tagName("li")).size());
-
-		List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
-		Assert.assertEquals(2, ps.size());
-
-		List<String> result = new ArrayList<>();
-		for (WebElement p : ps) {
-			result.add(p.getText());
-		}
-
-		Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
-
-	}
-
-	@Test
-	public void testAjaxArrayInsideObjectErrorTopic() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
-
-		driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobjecterrortopic.action");
-
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
-		WebElement errorContainer = driver.findElement(By.id("errorContainer"));
-
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-
-		List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
-		Assert.assertEquals(2, ps.size());
-
-		List<String> result = new ArrayList<>();
-		for (WebElement p : ps) {
-			result.add(p.getText());
-		}
-
-		Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
-
-	}
+        driver.findElements(By.tagName("li")).get(0).click();
+        Thread.sleep(1000);
+	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+    }
 }
+

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
@@ -1,11 +1,8 @@
 package com.jgeppert.jquery.autocompleter;
 
-import com.jgeppert.jquery.selenium.JQueryIdleCondition;
-import com.jgeppert.jquery.selenium.JQueryNoAnimations;
-import com.jgeppert.jquery.selenium.WebDriverFactory;
-import com.jgeppert.jquery.junit.category.HtmlUnitCategory;
-import com.jgeppert.jquery.junit.category.PhantomJSCategory;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -17,13 +14,16 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
+
+import com.jgeppert.jquery.junit.category.HtmlUnitCategory;
+import com.jgeppert.jquery.junit.category.PhantomJSCategory;
+import com.jgeppert.jquery.selenium.JQueryIdleCondition;
+import com.jgeppert.jquery.selenium.JQueryNoAnimations;
+import com.jgeppert.jquery.selenium.WebDriverFactory;
 
 @RunWith(Parameterized.class)
 @Category({HtmlUnitCategory.class, PhantomJSCategory.class})
@@ -31,18 +31,18 @@ public class AutocompleterTagIT {
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                 { "http://localhost:8080/regular" }, 
+                 { "http://localhost:8080/regular" },
                  { "http://localhost:8080/uncompressed" },
-                 { "http://localhost:8080/loadatonce" }, 
-                 { "http://localhost:8080/loadfromgoogle" }  
+                 { "http://localhost:8080/loadatonce" },
+                 { "http://localhost:8080/loadfromgoogle" }
            });
     }
-    
+
     private static final JQueryIdleCondition JQUERY_IDLE = new JQueryIdleCondition();
     private static final JQueryNoAnimations JQUERY_NO_ANIMATIONS = new JQueryNoAnimations();
 
-    private String baseUrl;        
-    private WebDriver driver;        
+    private String baseUrl;
+    private WebDriver driver;
 
     public AutocompleterTagIT(final String baseUrl) {
         this.baseUrl = baseUrl;
@@ -167,5 +167,56 @@ public class AutocompleterTagIT {
         Thread.sleep(1000);
 	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
     }
+
+	@Test
+	public void testAjaxArrayErrorTopic() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
+
+		driver.get(baseUrl + "/autocompleter/ajaxarrayerrortopic.action");
+
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		WebElement errorContainer = driver.findElement(By.id("errorContainer"));
+
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+		Assert.assertEquals(0, driver.findElements(By.tagName("li")).size());
+
+		List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
+		Assert.assertEquals(2, ps.size());
+
+		List<String> result = new ArrayList<>();
+		for (WebElement p : ps) {
+			result.add(p.getText());
+		}
+
+		Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
+
+	}
+
+	@Test
+	public void testAjaxArrayInsideObjectErrorTopic() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
+
+		driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobjecterrortopic.action");
+
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		WebElement errorContainer = driver.findElement(By.id("errorContainer"));
+
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+
+		List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
+		Assert.assertEquals(2, ps.size());
+
+		List<String> result = new ArrayList<>();
+		for (WebElement p : ps) {
+			result.add(p.getText());
+		}
+
+		Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
+
+	}
 }
 

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
@@ -1,13 +1,20 @@
 package com.jgeppert.jquery.autocompleter;
 
 <<<<<<< Upstream, based on origin/release/4.0.3
+<<<<<<< Upstream, based on origin/release/4.0.3
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.contains;
 =======
 import static org.hamcrest.Matchers.containsInAnyOrder;
 >>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
+=======
+import com.jgeppert.jquery.selenium.JQueryIdleCondition;
+import com.jgeppert.jquery.selenium.JQueryNoAnimations;
+import com.jgeppert.jquery.selenium.WebDriverFactory;
+import com.jgeppert.jquery.junit.category.HtmlUnitCategory;
+import com.jgeppert.jquery.junit.category.PhantomJSCategory;
+>>>>>>> 74116da reverted to fix code style
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -19,24 +26,25 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+<<<<<<< Upstream, based on origin/release/4.0.3
 <<<<<<< Upstream, based on origin/release/4.0.3
 import org.openqa.selenium.support.ui.ExpectedConditions;
 =======
 >>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
+=======
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+>>>>>>> 74116da reverted to fix code style
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import com.jgeppert.jquery.junit.category.HtmlUnitCategory;
-import com.jgeppert.jquery.junit.category.PhantomJSCategory;
-import com.jgeppert.jquery.selenium.JQueryIdleCondition;
-import com.jgeppert.jquery.selenium.JQueryNoAnimations;
-import com.jgeppert.jquery.selenium.WebDriverFactory;
-
 @RunWith(Parameterized.class)
-@Category({ HtmlUnitCategory.class, PhantomJSCategory.class })
+@Category({HtmlUnitCategory.class, PhantomJSCategory.class})
 public class AutocompleterTagIT {
+<<<<<<< Upstream, based on origin/release/4.0.3
 <<<<<<< Upstream, based on origin/release/4.0.3
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
@@ -58,7 +66,22 @@ public class AutocompleterTagIT {
 		                { "http://localhost:8080/loadatonce" }, { "http://localhost:8080/loadfromgoogle" } });
 	}
 >>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
+=======
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                 { "http://localhost:8080/regular" }, 
+                 { "http://localhost:8080/uncompressed" },
+                 { "http://localhost:8080/loadatonce" }, 
+                 { "http://localhost:8080/loadfromgoogle" }  
+           });
+    }
+    
+    private static final JQueryIdleCondition JQUERY_IDLE = new JQueryIdleCondition();
+    private static final JQueryNoAnimations JQUERY_NO_ANIMATIONS = new JQueryNoAnimations();
+>>>>>>> 74116da reverted to fix code style
 
+<<<<<<< Upstream, based on origin/release/4.0.3
 <<<<<<< Upstream, based on origin/release/4.0.3
     private String baseUrl;
     private WebDriver driver;
@@ -66,37 +89,43 @@ public class AutocompleterTagIT {
 	private static final JQueryIdleCondition JQUERY_IDLE = new JQueryIdleCondition();
 	private static final JQueryNoAnimations JQUERY_NO_ANIMATIONS = new JQueryNoAnimations();
 >>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
+=======
+    private String baseUrl;        
+    private WebDriver driver;        
+>>>>>>> 74116da reverted to fix code style
 
-	private String baseUrl;
-	private WebDriver driver;
+    public AutocompleterTagIT(final String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
 
-	public AutocompleterTagIT(final String baseUrl) {
-		this.baseUrl = baseUrl;
-	}
+    @Before
+    public void before() {
+        driver = WebDriverFactory.getWebDriver();
+    }
 
-	@Before
-	public void before() {
-		driver = WebDriverFactory.getWebDriver();
-	}
+    @After
+    public void after() {
+        driver.quit();
+    }
 
-	@After
-	public void after() {
-		driver.quit();
-	}
+    @Test
+    public void testListData() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
 
-	@Test
-	public void testListData() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
+        driver.get(baseUrl + "/autocompleter/list.action");
 
-		driver.get(baseUrl + "/autocompleter/list.action");
+        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        autocompleteInputWidget.sendKeys("j");
+        Thread.sleep(1000);
+        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+        autocompleteInputWidget.sendKeys("u");
+        Thread.sleep(1000);
+        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
+<<<<<<< Upstream, based on origin/release/4.0.3
 <<<<<<< Upstream, based on origin/release/4.0.3
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
@@ -122,25 +151,31 @@ public class AutocompleterTagIT {
 		Thread.sleep(1000);
 		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 >>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
+=======
+        driver.findElements(By.tagName("li")).get(0).click();
+        Thread.sleep(1000);
+	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+    }
+>>>>>>> 74116da reverted to fix code style
 
-		driver.findElements(By.tagName("li")).get(0).click();
-		Thread.sleep(1000);
-		Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
-	}
+    @Test
+    public void testAjaxArray() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
 
-	@Test
-	public void testAjaxArray() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
+        driver.get(baseUrl + "/autocompleter/ajaxarray.action");
 
-		driver.get(baseUrl + "/autocompleter/ajaxarray.action");
+        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        autocompleteInputWidget.sendKeys("j");
+        Thread.sleep(1000);
+        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+        autocompleteInputWidget.sendKeys("u");
+        Thread.sleep(1000);
+        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
+<<<<<<< Upstream, based on origin/release/4.0.3
 <<<<<<< Upstream, based on origin/release/4.0.3
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
@@ -151,25 +186,31 @@ public class AutocompleterTagIT {
 		Thread.sleep(1000);
 		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 >>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
+=======
+        driver.findElements(By.tagName("li")).get(0).click();
+        Thread.sleep(1000);
+	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+    }
+>>>>>>> 74116da reverted to fix code style
 
-		driver.findElements(By.tagName("li")).get(0).click();
-		Thread.sleep(1000);
-		Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
-	}
+    @Test
+    public void testAjaxArrayInsideObject() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
 
-	@Test
-	public void testAjaxArrayInsideObject() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
+        driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobject.action");
 
-		driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobject.action");
+        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        autocompleteInputWidget.sendKeys("j");
+        Thread.sleep(1000);
+        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+        autocompleteInputWidget.sendKeys("u");
+        Thread.sleep(1000);
+        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
+<<<<<<< Upstream, based on origin/release/4.0.3
 <<<<<<< Upstream, based on origin/release/4.0.3
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
@@ -180,25 +221,31 @@ public class AutocompleterTagIT {
 		Thread.sleep(1000);
 		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 >>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
+=======
+        driver.findElements(By.tagName("li")).get(0).click();
+        Thread.sleep(1000);
+	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+    }
+>>>>>>> 74116da reverted to fix code style
 
-		driver.findElements(By.tagName("li")).get(0).click();
-		Thread.sleep(1000);
-		Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
-	}
+    @Test
+    public void testAjaxMapInsideObject() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
 
-	@Test
-	public void testAjaxMapInsideObject() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
+        driver.get(baseUrl + "/autocompleter/ajaxmapinsideobject.action");
 
-		driver.get(baseUrl + "/autocompleter/ajaxmapinsideobject.action");
+        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        autocompleteInputWidget.sendKeys("j");
+        Thread.sleep(1000);
+        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+        autocompleteInputWidget.sendKeys("u");
+        Thread.sleep(1000);
+        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
+<<<<<<< Upstream, based on origin/release/4.0.3
 <<<<<<< Upstream, based on origin/release/4.0.3
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
@@ -209,25 +256,31 @@ public class AutocompleterTagIT {
 		Thread.sleep(1000);
 		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 >>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
+=======
+        driver.findElements(By.tagName("li")).get(0).click();
+        Thread.sleep(1000);
+	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+    }
+>>>>>>> 74116da reverted to fix code style
 
-		driver.findElements(By.tagName("li")).get(0).click();
-		Thread.sleep(1000);
-		Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
-	}
+    @Test
+    public void testAjaxObjectsInsideObject() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
 
-	@Test
-	public void testAjaxObjectsInsideObject() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
+        driver.get(baseUrl + "/autocompleter/ajaxobjectsinsideobject.action");
 
-		driver.get(baseUrl + "/autocompleter/ajaxobjectsinsideobject.action");
+        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+        autocompleteInputWidget.sendKeys("j");
+        Thread.sleep(1000);
+        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+        autocompleteInputWidget.sendKeys("u");
+        Thread.sleep(1000);
+        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
+<<<<<<< Upstream, based on origin/release/4.0.3
 <<<<<<< Upstream, based on origin/release/4.0.3
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
@@ -356,4 +409,11 @@ public class AutocompleterTagIT {
 
 	}
 >>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
+=======
+        driver.findElements(By.tagName("li")).get(0).click();
+        Thread.sleep(1000);
+	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+    }
+>>>>>>> 74116da reverted to fix code style
 }
+

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
@@ -1,19 +1,10 @@
 package com.jgeppert.jquery.autocompleter;
 
-<<<<<<< Upstream, based on origin/release/4.0.3
-<<<<<<< Upstream, based on origin/release/4.0.3
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.contains;
-=======
-import static org.hamcrest.Matchers.containsInAnyOrder;
->>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
-=======
 import com.jgeppert.jquery.selenium.JQueryIdleCondition;
 import com.jgeppert.jquery.selenium.JQueryNoAnimations;
 import com.jgeppert.jquery.selenium.WebDriverFactory;
 import com.jgeppert.jquery.junit.category.HtmlUnitCategory;
 import com.jgeppert.jquery.junit.category.PhantomJSCategory;
->>>>>>> 74116da reverted to fix code style
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,43 +21,13 @@ import org.junit.runners.Parameterized;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-<<<<<<< Upstream, based on origin/release/4.0.3
-<<<<<<< Upstream, based on origin/release/4.0.3
-import org.openqa.selenium.support.ui.ExpectedConditions;
-=======
->>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
-=======
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
->>>>>>> 74116da reverted to fix code style
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 @RunWith(Parameterized.class)
 @Category({HtmlUnitCategory.class, PhantomJSCategory.class})
 public class AutocompleterTagIT {
-<<<<<<< Upstream, based on origin/release/4.0.3
-<<<<<<< Upstream, based on origin/release/4.0.3
-    @Parameterized.Parameters
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-                 { "http://localhost:8080/regular" },
-                 { "http://localhost:8080/uncompressed" },
-                 { "http://localhost:8080/loadatonce" },
-                 { "http://localhost:8080/loadfromgoogle" }
-           });
-    }
-
-    private static final JQueryIdleCondition JQUERY_IDLE = new JQueryIdleCondition();
-    private static final JQueryNoAnimations JQUERY_NO_ANIMATIONS = new JQueryNoAnimations();
-=======
-	@Parameterized.Parameters
-	public static Collection<Object[]> data() {
-		return Arrays
-		        .asList(new Object[][] { { "http://localhost:8080/regular" }, { "http://localhost:8080/uncompressed" },
-		                { "http://localhost:8080/loadatonce" }, { "http://localhost:8080/loadfromgoogle" } });
-	}
->>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
-=======
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
@@ -79,20 +40,9 @@ public class AutocompleterTagIT {
     
     private static final JQueryIdleCondition JQUERY_IDLE = new JQueryIdleCondition();
     private static final JQueryNoAnimations JQUERY_NO_ANIMATIONS = new JQueryNoAnimations();
->>>>>>> 74116da reverted to fix code style
 
-<<<<<<< Upstream, based on origin/release/4.0.3
-<<<<<<< Upstream, based on origin/release/4.0.3
-    private String baseUrl;
-    private WebDriver driver;
-=======
-	private static final JQueryIdleCondition JQUERY_IDLE = new JQueryIdleCondition();
-	private static final JQueryNoAnimations JQUERY_NO_ANIMATIONS = new JQueryNoAnimations();
->>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
-=======
     private String baseUrl;        
     private WebDriver driver;        
->>>>>>> 74116da reverted to fix code style
 
     public AutocompleterTagIT(final String baseUrl) {
         this.baseUrl = baseUrl;
@@ -125,38 +75,10 @@ public class AutocompleterTagIT {
         Thread.sleep(1000);
         Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-<<<<<<< Upstream, based on origin/release/4.0.3
-<<<<<<< Upstream, based on origin/release/4.0.3
-        driver.findElements(By.tagName("li")).get(0).click();
-        Thread.sleep(1000);
-        Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
-
-        //verify #46 - handling of cssClass attribute
-        Assert.assertThat(autocompleteInputWidget.getAttribute("class"), containsString("extra-class"));
-    }
-
-    @Test
-    public void testListDataWithCssErrorClass() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
-        this.testListData();
-        driver.get(baseUrl + "/autocompleter/list.action?addError=true");
-
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
-
-        //verify #46 - handling of cssErrorClass attribute
-        Assert.assertThat(autocompleteInputWidget.getAttribute("class"), containsString("error-class"));
-    }
-=======
-		autocompleteInputWidget.sendKeys("u");
-		Thread.sleep(1000);
-		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
->>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
-=======
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
 	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
->>>>>>> 74116da reverted to fix code style
 
     @Test
     public void testAjaxArray() throws InterruptedException {
@@ -175,23 +97,10 @@ public class AutocompleterTagIT {
         Thread.sleep(1000);
         Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-<<<<<<< Upstream, based on origin/release/4.0.3
-<<<<<<< Upstream, based on origin/release/4.0.3
-        driver.findElements(By.tagName("li")).get(0).click();
-        Thread.sleep(1000);
-        Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
-    }
-=======
-		autocompleteInputWidget.sendKeys("u");
-		Thread.sleep(1000);
-		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
->>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
-=======
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
 	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
->>>>>>> 74116da reverted to fix code style
 
     @Test
     public void testAjaxArrayInsideObject() throws InterruptedException {
@@ -210,23 +119,10 @@ public class AutocompleterTagIT {
         Thread.sleep(1000);
         Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-<<<<<<< Upstream, based on origin/release/4.0.3
-<<<<<<< Upstream, based on origin/release/4.0.3
-        driver.findElements(By.tagName("li")).get(0).click();
-        Thread.sleep(1000);
-        Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
-    }
-=======
-		autocompleteInputWidget.sendKeys("u");
-		Thread.sleep(1000);
-		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
->>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
-=======
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
 	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
->>>>>>> 74116da reverted to fix code style
 
     @Test
     public void testAjaxMapInsideObject() throws InterruptedException {
@@ -245,23 +141,10 @@ public class AutocompleterTagIT {
         Thread.sleep(1000);
         Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-<<<<<<< Upstream, based on origin/release/4.0.3
-<<<<<<< Upstream, based on origin/release/4.0.3
-        driver.findElements(By.tagName("li")).get(0).click();
-        Thread.sleep(1000);
-        Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
-    }
-=======
-		autocompleteInputWidget.sendKeys("u");
-		Thread.sleep(1000);
-		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
->>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
-=======
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
 	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
     }
->>>>>>> 74116da reverted to fix code style
 
     @Test
     public void testAjaxObjectsInsideObject() throws InterruptedException {
@@ -280,140 +163,8 @@ public class AutocompleterTagIT {
         Thread.sleep(1000);
         Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
-<<<<<<< Upstream, based on origin/release/4.0.3
-<<<<<<< Upstream, based on origin/release/4.0.3
-        driver.findElements(By.tagName("li")).get(0).click();
-        Thread.sleep(1000);
-        Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
-    }
-
-
-    /**
-     * Issue #36 - verify that errorTopics are fired if AJAX request fail.
-     * Autocompleter waiting for a JSON array
-     *
-     * @throws InterruptedException
-     */
-    @Test
-    public void testAjaxArrayErrorTopic() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
-
-        driver.get(baseUrl + "/autocompleter/ajaxarrayerrortopic.action");
-
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
-        WebElement errorContainer = driver.findElement(By.id("errorContainer"));
-
-        autocompleteInputWidget.sendKeys("j");
-        wait.until(ExpectedConditions.presenceOfNestedElementLocatedBy(errorContainer, By.tagName("p")));
-        Assert.assertEquals(0, driver.findElements(By.tagName("li")).size());
-
-        List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
-        Assert.assertEquals(2, ps.size());
-
-        List<String> result = new ArrayList<>();
-        for (WebElement p : ps) {
-            result.add(p.getText());
-        }
-
-        Assert.assertThat(result, contains("topic1", "topic2"));
-
-    }
-
-    /**
-     * Issue #36 - verify that errorTopics are fired if AJAX request fail.
-     * Autocompleter waiting for a JSON array inside an object
-     *
-     * @throws InterruptedException
-     */
-    @Test
-    public void testAjaxArrayInsideObjectErrorTopic() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
-
-        driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobjecterrortopic.action");
-
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
-        WebElement errorContainer = driver.findElement(By.id("errorContainer"));
-
-        autocompleteInputWidget.sendKeys("j");
-        wait.until(ExpectedConditions.presenceOfNestedElementLocatedBy(errorContainer, By.tagName("p")));
-
-        List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
-        Assert.assertEquals(2, ps.size());
-
-        List<String> result = new ArrayList<>();
-        for (WebElement p : ps) {
-            result.add(p.getText());
-        }
-
-        Assert.assertThat(result, contains("topic1", "topic2"));
-
-    }
-=======
-		autocompleteInputWidget.sendKeys("u");
-		Thread.sleep(1000);
-		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
-
-		driver.findElements(By.tagName("li")).get(0).click();
-		Thread.sleep(1000);
-		Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
-	}
-
-	@Test
-	public void testAjaxArrayErrorTopic() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
-
-		driver.get(baseUrl + "/autocompleter/ajaxarrayerrortopic.action");
-
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
-		WebElement errorContainer = driver.findElement(By.id("errorContainer"));
-
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-		Assert.assertEquals(0, driver.findElements(By.tagName("li")).size());
-
-		List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
-		Assert.assertEquals(2, ps.size());
-
-		List<String> result = new ArrayList<>();
-		for (WebElement p : ps) {
-			result.add(p.getText());
-		}
-
-		Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
-
-	}
-
-	@Test
-	public void testAjaxArrayInsideObjectErrorTopic() throws InterruptedException {
-		WebDriverWait wait = new WebDriverWait(driver, 30);
-
-		driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobjecterrortopic.action");
-
-		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
-		WebElement errorContainer = driver.findElement(By.id("errorContainer"));
-
-		autocompleteInputWidget.sendKeys("j");
-		Thread.sleep(1000);
-
-		List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
-		Assert.assertEquals(2, ps.size());
-
-		List<String> result = new ArrayList<>();
-		for (WebElement p : ps) {
-			result.add(p.getText());
-		}
-
-		Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
-
-	}
->>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
-=======
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
 	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
     }
->>>>>>> 74116da reverted to fix code style
 }
-

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
@@ -17,14 +17,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-<<<<<<< Upstream, based on origin/release/4.0.3
-=======
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
->>>>>>> 7ccdda6 trying to use WebDriverWait instead of Thread.sleep
 
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
@@ -85,7 +77,7 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-        Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
 
     @Test
@@ -107,7 +99,7 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-        Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
 
     @Test
@@ -129,7 +121,7 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-        Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+	Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
 
     @Test
@@ -151,7 +143,7 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-        Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
     }
 
     @Test
@@ -173,58 +165,6 @@ public class AutocompleterTagIT {
 
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
-        Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+	Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
     }
-<<<<<<< Upstream, based on origin/release/4.0.3
-=======
-
-    @Test
-    public void testAjaxArrayErrorTopic() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
-
-        driver.get(baseUrl + "/autocompleter/ajaxarrayerrortopic.action");
-
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
-        WebElement errorContainer = driver.findElement(By.id("errorContainer"));
-
-        autocompleteInputWidget.sendKeys("j");
-        wait.until(ExpectedConditions.presenceOfNestedElementLocatedBy(errorContainer, By.tagName("p")));
-        Assert.assertEquals(0, driver.findElements(By.tagName("li")).size());
-
-        List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
-        Assert.assertEquals(2, ps.size());
-
-        List<String> result = new ArrayList<>();
-        for (WebElement p : ps) {
-            result.add(p.getText());
-        }
-
-        Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
-
-    }
-
-    @Test
-    public void testAjaxArrayInsideObjectErrorTopic() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
-
-        driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobjecterrortopic.action");
-
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
-        WebElement errorContainer = driver.findElement(By.id("errorContainer"));
-
-        autocompleteInputWidget.sendKeys("j");
-        wait.until(ExpectedConditions.presenceOfNestedElementLocatedBy(errorContainer, By.tagName("p")));
-
-        List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
-        Assert.assertEquals(2, ps.size());
-
-        List<String> result = new ArrayList<>();
-        for (WebElement p : ps) {
-            result.add(p.getText());
-        }
-
-        Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
-
-    }
->>>>>>> 7ccdda6 trying to use WebDriverWait instead of Thread.sleep
 }

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/autocompleter/AutocompleterTagIT.java
@@ -1,7 +1,11 @@
 package com.jgeppert.jquery.autocompleter;
 
+<<<<<<< Upstream, based on origin/release/4.0.3
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.contains;
+=======
+import static org.hamcrest.Matchers.containsInAnyOrder;
+>>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,7 +22,10 @@ import org.junit.runners.Parameterized;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+<<<<<<< Upstream, based on origin/release/4.0.3
 import org.openqa.selenium.support.ui.ExpectedConditions;
+=======
+>>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import com.jgeppert.jquery.junit.category.HtmlUnitCategory;
@@ -28,8 +35,9 @@ import com.jgeppert.jquery.selenium.JQueryNoAnimations;
 import com.jgeppert.jquery.selenium.WebDriverFactory;
 
 @RunWith(Parameterized.class)
-@Category({HtmlUnitCategory.class, PhantomJSCategory.class})
+@Category({ HtmlUnitCategory.class, PhantomJSCategory.class })
 public class AutocompleterTagIT {
+<<<<<<< Upstream, based on origin/release/4.0.3
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
@@ -42,41 +50,54 @@ public class AutocompleterTagIT {
 
     private static final JQueryIdleCondition JQUERY_IDLE = new JQueryIdleCondition();
     private static final JQueryNoAnimations JQUERY_NO_ANIMATIONS = new JQueryNoAnimations();
+=======
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() {
+		return Arrays
+		        .asList(new Object[][] { { "http://localhost:8080/regular" }, { "http://localhost:8080/uncompressed" },
+		                { "http://localhost:8080/loadatonce" }, { "http://localhost:8080/loadfromgoogle" } });
+	}
+>>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
 
+<<<<<<< Upstream, based on origin/release/4.0.3
     private String baseUrl;
     private WebDriver driver;
+=======
+	private static final JQueryIdleCondition JQUERY_IDLE = new JQueryIdleCondition();
+	private static final JQueryNoAnimations JQUERY_NO_ANIMATIONS = new JQueryNoAnimations();
+>>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
 
-    public AutocompleterTagIT(final String baseUrl) {
-        this.baseUrl = baseUrl;
-    }
+	private String baseUrl;
+	private WebDriver driver;
 
-    @Before
-    public void before() {
-        driver = WebDriverFactory.getWebDriver();
-    }
+	public AutocompleterTagIT(final String baseUrl) {
+		this.baseUrl = baseUrl;
+	}
 
-    @After
-    public void after() {
-        driver.quit();
-    }
+	@Before
+	public void before() {
+		driver = WebDriverFactory.getWebDriver();
+	}
 
-    @Test
-    public void testListData() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
+	@After
+	public void after() {
+		driver.quit();
+	}
 
-        driver.get(baseUrl + "/autocompleter/list.action");
+	@Test
+	public void testListData() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
 
-        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		driver.get(baseUrl + "/autocompleter/list.action");
 
-        autocompleteInputWidget.sendKeys("j");
-        Thread.sleep(1000);
-        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-        autocompleteInputWidget.sendKeys("u");
-        Thread.sleep(1000);
-        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
+<<<<<<< Upstream, based on origin/release/4.0.3
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
         Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
@@ -96,90 +117,118 @@ public class AutocompleterTagIT {
         //verify #46 - handling of cssErrorClass attribute
         Assert.assertThat(autocompleteInputWidget.getAttribute("class"), containsString("error-class"));
     }
+=======
+		autocompleteInputWidget.sendKeys("u");
+		Thread.sleep(1000);
+		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+>>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
 
-    @Test
-    public void testAjaxArray() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
+		driver.findElements(By.tagName("li")).get(0).click();
+		Thread.sleep(1000);
+		Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+	}
 
-        driver.get(baseUrl + "/autocompleter/ajaxarray.action");
+	@Test
+	public void testAjaxArray() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
 
-        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		driver.get(baseUrl + "/autocompleter/ajaxarray.action");
 
-        autocompleteInputWidget.sendKeys("j");
-        Thread.sleep(1000);
-        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-        autocompleteInputWidget.sendKeys("u");
-        Thread.sleep(1000);
-        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
+<<<<<<< Upstream, based on origin/release/4.0.3
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
         Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
+=======
+		autocompleteInputWidget.sendKeys("u");
+		Thread.sleep(1000);
+		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+>>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
 
-    @Test
-    public void testAjaxArrayInsideObject() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
+		driver.findElements(By.tagName("li")).get(0).click();
+		Thread.sleep(1000);
+		Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+	}
 
-        driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobject.action");
+	@Test
+	public void testAjaxArrayInsideObject() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
 
-        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobject.action");
 
-        autocompleteInputWidget.sendKeys("j");
-        Thread.sleep(1000);
-        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-        autocompleteInputWidget.sendKeys("u");
-        Thread.sleep(1000);
-        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
+<<<<<<< Upstream, based on origin/release/4.0.3
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
         Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
     }
+=======
+		autocompleteInputWidget.sendKeys("u");
+		Thread.sleep(1000);
+		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+>>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
 
-    @Test
-    public void testAjaxMapInsideObject() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
+		driver.findElements(By.tagName("li")).get(0).click();
+		Thread.sleep(1000);
+		Assert.assertEquals("June", autocompleteInput.getAttribute("value"));
+	}
 
-        driver.get(baseUrl + "/autocompleter/ajaxmapinsideobject.action");
+	@Test
+	public void testAjaxMapInsideObject() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
 
-        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		driver.get(baseUrl + "/autocompleter/ajaxmapinsideobject.action");
 
-        autocompleteInputWidget.sendKeys("j");
-        Thread.sleep(1000);
-        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-        autocompleteInputWidget.sendKeys("u");
-        Thread.sleep(1000);
-        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
+<<<<<<< Upstream, based on origin/release/4.0.3
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
         Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
     }
+=======
+		autocompleteInputWidget.sendKeys("u");
+		Thread.sleep(1000);
+		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+>>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
 
-    @Test
-    public void testAjaxObjectsInsideObject() throws InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 30);
+		driver.findElements(By.tagName("li")).get(0).click();
+		Thread.sleep(1000);
+		Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+	}
 
-        driver.get(baseUrl + "/autocompleter/ajaxobjectsinsideobject.action");
+	@Test
+	public void testAjaxObjectsInsideObject() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
 
-        WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
-        WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		driver.get(baseUrl + "/autocompleter/ajaxobjectsinsideobject.action");
 
-        autocompleteInputWidget.sendKeys("j");
-        Thread.sleep(1000);
-        Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
 
-        autocompleteInputWidget.sendKeys("u");
-        Thread.sleep(1000);
-        Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+		Assert.assertEquals(3, driver.findElements(By.tagName("li")).size());
 
+<<<<<<< Upstream, based on origin/release/4.0.3
         driver.findElements(By.tagName("li")).get(0).click();
         Thread.sleep(1000);
         Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
@@ -246,5 +295,65 @@ public class AutocompleterTagIT {
         Assert.assertThat(result, contains("topic1", "topic2"));
 
     }
-}
+=======
+		autocompleteInputWidget.sendKeys("u");
+		Thread.sleep(1000);
+		Assert.assertEquals(2, driver.findElements(By.tagName("li")).size());
 
+		driver.findElements(By.tagName("li")).get(0).click();
+		Thread.sleep(1000);
+		Assert.assertEquals("6", autocompleteInput.getAttribute("value"));
+	}
+
+	@Test
+	public void testAjaxArrayErrorTopic() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
+
+		driver.get(baseUrl + "/autocompleter/ajaxarrayerrortopic.action");
+
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		WebElement errorContainer = driver.findElement(By.id("errorContainer"));
+
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+		Assert.assertEquals(0, driver.findElements(By.tagName("li")).size());
+
+		List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
+		Assert.assertEquals(2, ps.size());
+
+		List<String> result = new ArrayList<>();
+		for (WebElement p : ps) {
+			result.add(p.getText());
+		}
+
+		Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
+
+	}
+
+	@Test
+	public void testAjaxArrayInsideObjectErrorTopic() throws InterruptedException {
+		WebDriverWait wait = new WebDriverWait(driver, 30);
+
+		driver.get(baseUrl + "/autocompleter/ajaxarrayinsideobjecterrortopic.action");
+
+		WebElement autocompleteInput = driver.findElement(By.id("autocompleterMonths"));
+		WebElement autocompleteInputWidget = driver.findElement(By.id("autocompleterMonths_widget"));
+		WebElement errorContainer = driver.findElement(By.id("errorContainer"));
+
+		autocompleteInputWidget.sendKeys("j");
+		Thread.sleep(1000);
+
+		List<WebElement> ps = errorContainer.findElements(By.tagName("p"));
+		Assert.assertEquals(2, ps.size());
+
+		List<String> result = new ArrayList<>();
+		for (WebElement p : ps) {
+			result.add(p.getText());
+		}
+
+		Assert.assertThat(result, containsInAnyOrder("topic1", "topic2"));
+
+	}
+>>>>>>> 12c183d references #36 - add integration test for Autocompleter's error topics
+}

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/div/DivTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/div/DivTagIT.java
@@ -74,7 +74,6 @@ public class DivTagIT {
         WebDriverWait wait = new WebDriverWait(driver, 30);
 
         driver.get(baseUrl + "/div/events.action");
-        WebElement ajaxDiv = driver.findElement(By.id("ajaxdiv"));
 
         wait.until(JQUERY_IDLE);
         wait.until(ExpectedConditions.alertIsPresent());
@@ -91,6 +90,8 @@ public class DivTagIT {
         Assert.assertEquals("Complete div", alert.getText());
 
         alert.accept();
+
+        WebElement ajaxDiv = driver.findElement(By.id("ajaxdiv"));
 
         Assert.assertEquals("This is simple text from an ajax call.", ajaxDiv.getText());
     }

--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/submit/SubmitTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/submit/SubmitTagIT.java
@@ -17,7 +17,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WebDriver;
@@ -25,7 +24,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 @RunWith(Parameterized.class)
-@Category({HtmlUnitCategory.class})
+@Category({HtmlUnitCategory.class, PhantomJSCategory.class})
 public class SubmitTagIT {
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
@@ -57,7 +56,6 @@ public class SubmitTagIT {
     }
 
     @Test
-    @Category({PhantomJSCategory.class})
     public void testSimpleFormSubmit() {
         WebDriverWait wait = new WebDriverWait(driver, 30);
 
@@ -85,7 +83,6 @@ public class SubmitTagIT {
     }
 
     @Test
-    @Category({PhantomJSCategory.class})
     public void testFormSubmitOutside() {
         WebDriverWait wait = new WebDriverWait(driver, 30);
 
@@ -127,27 +124,15 @@ public class SubmitTagIT {
         ajaxSubmit.click();
 
         wait.until(JQUERY_IDLE);
-        wait.until(ExpectedConditions.alertIsPresent());
-
-        Alert alert = driver.switchTo().alert();
-
-        Assert.assertEquals("ajax submit clicked", alert.getText());
-
-        alert.accept();
 
         wait.until(JQUERY_IDLE);
-        wait.until(ExpectedConditions.alertIsPresent());
-        alert = driver.switchTo().alert();
 
-        Assert.assertEquals("ajax submit complete", alert.getText());
-
-        alert.accept();
-
+	WebElement ajaxeventsdiv = driver.findElement(By.id("ajaxeventsdiv"));
+        Assert.assertEquals("ajax submit clickedajax submit complete", ajaxeventsdiv.getText());
         Assert.assertEquals("Echo : something to echo", formResult.getText());
     }
  
     @Test
-    @Category({PhantomJSCategory.class})
     public void testFormSubmitListenTopics() {
         WebDriverWait wait = new WebDriverWait(driver, 30);
 

--- a/struts2-jquery-mobile-plugin/pom.xml
+++ b/struts2-jquery-mobile-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     <artifactId>struts2-jquery-mobile-plugin</artifactId>
     <name>Struts 2 jQuery Mobile Plugin</name>

--- a/struts2-jquery-mobile-showcase/pom.xml
+++ b/struts2-jquery-mobile-showcase/pom.xml
@@ -18,7 +18,7 @@
     </scm>
 
     <properties>
-        <log4j2.version>2.7</log4j2.version>
+        <log4j2.version>2.9.0</log4j2.version>
     </properties>
 
     <dependencies>

--- a/struts2-jquery-mobile-showcase/pom.xml
+++ b/struts2-jquery-mobile-showcase/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     <artifactId>struts2-jquery-mobile-showcase</artifactId>
     <name>Struts 2 jQuery Mobile Showcase</name>

--- a/struts2-jquery-plugin/pom.xml
+++ b/struts2-jquery-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     <artifactId>struts2-jquery-plugin</artifactId>
     <name>Struts 2 jQuery Plugin</name>

--- a/struts2-jquery-plugin/src/main/resources/template/jquery/autocompleter-close.ftl
+++ b/struts2-jquery-plugin/src/main/resources/template/jquery/autocompleter-close.ftl
@@ -59,6 +59,10 @@ jQuery(document).ready(function () {
   <#if parameters.onSelectTopics?exists>
 	options_${escapedOptionId?html}.onselecttopics = "${parameters.onSelectTopics?html}";
   </#if>
+  <#if parameters.requestType?exists>
+	options_${escapedOptionId?html}.requesttype = "${parameters.requestType?html}";
+  </#if>
+
   <#if parameters.list?? && !parameters.listKey?? && !parameters.selectBox?? &&  !parameters.hrefUrl??>
 	options_${escapedOptionId?html}.list = new Array();
 <@s.iterator value="parameters.list">

--- a/struts2-jquery-plugin/src/main/resources/template/jquery/autocompleter.ftl
+++ b/struts2-jquery-plugin/src/main/resources/template/jquery/autocompleter.ftl
@@ -18,6 +18,33 @@
  * under the License.
  */
 -->
+<#assign hasFieldErrors = parameters.widgetname?? && fieldErrors?? && fieldErrors[parameters.widgetname]??/>
+<input type="hidden"
+    <#if parameters.widgetid?if_exists != "">
+        id="${parameters.widgetid?html}"<#rt/>
+    </#if>
+    <#if parameters.nameValue??>
+        value="<@s.property value="parameters.nameValue"/>"<#rt/>
+    </#if>
+    <#if parameters.widgetname?if_exists != "">
+        name="${parameters.widgetname?html}"<#rt/>
+    </#if>
+    <#if parameters.cssClass?has_content && !(hasFieldErrors && parameters.cssErrorClass??)>
+        class="${parameters.cssClass?html}"<#rt/>
+    <#elseif parameters.cssClass?has_content && (hasFieldErrors && parameters.cssErrorClass??)>
+        class="${parameters.cssClass?html} ${parameters.cssErrorClass?html}"<#rt/>
+    <#elseif !(parameters.cssClass?has_content) && (hasFieldErrors && parameters.cssErrorClass??)>
+        class="${parameters.cssErrorClass?html}"<#rt/>
+    </#if>
+    <#if parameters.cssStyle?has_content && !(hasFieldErrors && (parameters.cssErrorStyle?? || parameters.cssErrorClass??))>
+        style="${parameters.cssStyle?html}"<#rt/>
+    <#elseif hasFieldErrors && parameters.cssErrorStyle??>
+        style="${parameters.cssErrorStyle?html}"<#rt/>
+    </#if>
+    <#if parameters.disabled?default(false)>
+        disabled="disabled"<#rt/>
+    </#if>
+/>
 <#if parameters.parentTheme == 'xhtml' || parameters.parentTheme == 'css_xhtml' || parameters.parentTheme == 'simple'>
 	<#if parameters.parentTheme == 'xhtml'>
 		<#include "/${parameters.templateDir}/xhtml/controlheader.ftl" />
@@ -25,20 +52,6 @@
 	<#if parameters.parentTheme == 'css_xhtml'>
 		<#include "/${parameters.templateDir}/css_xhtml/controlheader.ftl" />
 	</#if>
-		<input type="hidden"
-		  <#if parameters.widgetid?if_exists != "">
-		    id="${parameters.widgetid?html}"<#rt/>
-		  </#if>
-		  <#if parameters.nameValue??>
-		    value="<@s.property value="parameters.nameValue"/>"<#rt/>
-		  </#if>
-		  <#if parameters.widgetname?if_exists != "">
-		 	name="${parameters.widgetname?html}"<#rt/>
-		  </#if>
-		  <#if parameters.disabled?default(false)>
-		    disabled="disabled"<#rt/>
-		  </#if>
-		/>
 	<#if (parameters.list?? && parameters.listKey??) || parameters.selectBox??>
 		<#include "/${parameters.templateDir}/simple/select.ftl" />
   	<#else>
@@ -51,20 +64,6 @@
 		<#include "/${parameters.templateDir}/css_xhtml/controlfooter.ftl" />
 	</#if>
 <#else>
-	<input type="hidden"
-	  <#if parameters.widgetid?if_exists != "">
-	    id="${parameters.widgetid?html}"<#rt/>
-	  </#if>
-	  <#if parameters.nameValue??>
-	    value="<@s.property value="parameters.nameValue"/>"<#rt/>
-	  </#if>
-	  <#if parameters.widgetname?if_exists != "">
-	 	name="${parameters.widgetname?html}"<#rt/>
-	  </#if>
-	  <#if parameters.disabled?default(false)>
-	    disabled="disabled"<#rt/>
-	  </#if>
-	/>
 	<#if (parameters.list?? && parameters.listKey??) || parameters.selectBox??>
 		<#include "/${parameters.templateDir}/${parameters.parentTheme}/select.ftl" />
   	<#else>

--- a/struts2-jquery-plugin/src/main/resources/template/js/plugins/jquery.combobox.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/plugins/jquery.combobox.js
@@ -22,7 +22,7 @@
             var classes = "s2j-combobox-input ui-widget ui-widget-content ui-state-default ui-corner-left";
             var elemClasses = this.element.attr("class");
             if (typeof elemClasses != 'undefined' && elemClasses != ""){
-            	classes = classes + " " + elemClasses;
+                classes = classes + " " + elemClasses;
             }
             this.input = $( "<input>" )
                 .appendTo( this.wrapper )

--- a/struts2-jquery-plugin/src/main/resources/template/js/plugins/jquery.combobox.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/plugins/jquery.combobox.js
@@ -18,11 +18,17 @@
             var self = this.element;
             var selected = this.element.children( ":selected" ),
                 value = selected.val() ? selected.text() : "";
+            //Fixes #46 add custom/error classes to widget
+            var classes = "s2j-combobox-input ui-widget ui-widget-content ui-state-default ui-corner-left";
+            var elemClasses = this.element.attr("class");
+            if (typeof elemClasses != 'undefined' && elemClasses != ""){
+            	classes = classes + " " + elemClasses;
+            }
             this.input = $( "<input>" )
                 .appendTo( this.wrapper )
                 .val( value )
                 .attr( "title", "" )
-                .addClass( "s2j-combobox-input ui-widget ui-widget-content ui-state-default ui-corner-left" )
+                .addClass( classes )
                 .autocomplete({
                     delay: 0,
                     minLength: 0,

--- a/struts2-jquery-plugin/src/main/resources/template/js/plugins/jquery.combobox.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/plugins/jquery.combobox.js
@@ -22,7 +22,11 @@
             var classes = "s2j-combobox-input ui-widget ui-widget-content ui-state-default ui-corner-left";
             var elemClasses = this.element.attr("class");
             if (typeof elemClasses != 'undefined' && elemClasses != ""){
+<<<<<<< Upstream, based on origin/release/4.0.3
                 classes = classes + " " + elemClasses;
+=======
+            	classes = classes + " " + elemClasses;
+>>>>>>> 8c708c0 Fixes #46 
             }
             this.input = $( "<input>" )
                 .appendTo( this.wrapper )

--- a/struts2-jquery-plugin/src/main/resources/template/js/plugins/jquery.combobox.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/plugins/jquery.combobox.js
@@ -17,16 +17,12 @@
         _createAutocomplete: function() {
             var self = this.element;
             var selected = this.element.children( ":selected" ),
-                value = selected.val() ? selected.text() : "";
+                value = selected.val() ? selected.text() : "";       
             //Fixes #46 add custom/error classes to widget
             var classes = "s2j-combobox-input ui-widget ui-widget-content ui-state-default ui-corner-left";
             var elemClasses = this.element.attr("class");
             if (typeof elemClasses != 'undefined' && elemClasses != ""){
-<<<<<<< Upstream, based on origin/release/4.0.3
                 classes = classes + " " + elemClasses;
-=======
-            	classes = classes + " " + elemClasses;
->>>>>>> 8c708c0 Fixes #46 
             }
             this.input = $( "<input>" )
                 .appendTo( this.wrapper )

--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.struts2.js
@@ -84,16 +84,16 @@
 	/**Change Parameter Value in URL */
 	changeParam : function(url, param, value) {
 		var ua = url.split("?"), // split url
-			pa = ua[1].split("&"), // split query 
+			pa = ua[1].split("&"), // split query
 			ia = [],
-			i; 
-		for (i=0; i < pa.length; i++) { 
-			ia = pa[i].split("="); // split name/value 
-			if (ia[0] === param) { 
-				pa[i] = ia[0] + "=" + value; 
+			i;
+		for (i=0; i < pa.length; i++) {
+			ia = pa[i].split("="); // split name/value
+			if (ia[0] === param) {
+				pa[i] = ia[0] + "=" + value;
 			}
 		}
-		return ua[0] + "?" + pa.join("&"); 
+		return ua[0] + "?" + pa.join("&");
 	},
 
 	/** Load required JavaScript Resourcess */
@@ -114,9 +114,9 @@
 			files = files.split(",");
 		}
 		$.each(files, function(i, file) {
-			
+
 			file = self.addParam(file, "s2j="+$.struts2_jquery.version);
-			
+
 			if (!$.struts2_jquery.scriptCache[file]) {
 				self.log('load require script ' + (path + file));
 				$.ajax( {
@@ -195,7 +195,7 @@
 		if (!self.loadAtOnce) {
 			self.require("js/plugins/jquery.form" + self.minSuffix + ".js");
 		}
-		
+
 		params.type = "POST";
 		params.data = {
 				"struts.enableJSONValidation": true,
@@ -557,7 +557,7 @@
 		$(window).bind('hashchange', params, function(e) {
 			var topic = e.getState(e.data.target) || '';
 			$.each(e.fragment.split('&'), function(i, f) {
-				var fragment = f.split('='); 
+				var fragment = f.split('=');
 				if(self.historyelements[fragment[0]] !== fragment[1] && fragment[1] !== self.lasttopic ) {
 					self.lasttopic = topic;
 					$.publish(fragment[1], e.data.options);
@@ -572,7 +572,7 @@
 			actionTopic = '_sj_action_' + o.id,
 			href = o.href,
 			effect = {};
-			
+
 		o.actionTopic = actionTopic;
 
 		if (href === null || href === "") {
@@ -647,7 +647,7 @@
 			effect = {},
 			bindel = $elem,
 			eventsStr = 'click';
-		
+
 		self.log('container : ' + o.id);
 		self.action($elem, o, self.handler.load, 'div');
 
@@ -739,12 +739,12 @@
 					});
 				}
 			}
-			
+
 			if (ui && o.resizable) {
 				ui.resizable($elem, o);
 			}
 		}
-		
+
 		if (ui && o.draggable) {
 			ui.draggable($elem, o);
 		}
@@ -757,7 +757,7 @@
 		if (ui && o.sortable) {
 			ui.sortable($elem, o);
 		}
-		
+
 		if (o.onblurtopics) {
 			$.each(o.onblurtopics.split(','), function(i, topic) {
 				$elem.blur( function() {
@@ -826,7 +826,7 @@
 				});
 			}
 		}
-		
+
 	},
 
 	/** Handle dynamic Select Boxes */
@@ -854,7 +854,10 @@
 		}
 		if (o.autocomplete) {
 			if (!self.loadAtOnce) {
-				self.require( [ "js/base/widget" + self.minSuffix + ".js", "js/base/position" + self.minSuffix + ".js", "js/base/menu" + self.minSuffix + ".js", "js/base/button" + self.minSuffix + ".js", "js/base/autocomplete" + self.minSuffix + ".js" ]);
+				self.require( [ "js/base/keycode" + self.minSuffix + ".js",
+			                    "js/base/safe-active-element" + self.minSuffix + ".js",
+				                "js/base/widget" + self.minSuffix + ".js", "js/base/position" + self.minSuffix + ".js",
+				                "js/base/menu" + self.minSuffix + ".js", "js/base/button" + self.minSuffix + ".js", "js/base/tooltip" + self.minSuffix + ".js","js/base/unique-id" + self.minSuffix + ".js","js/base/autocomplete" + self.minSuffix + ".js" ]);
 			}
             self.requireCss("themes/s2j-combobox.css");
 			self.require([ "js/plugins/jquery.combobox" + self.minSuffix + ".js" ]);
@@ -869,7 +872,7 @@
 			cform,cf,formid,randomid;
 
 		o.preventAction = true;
-		
+
 		if (o.opendialog) {
 			$.struts2_jquery_ui.opendialog($elem, o);
 		}
@@ -946,8 +949,8 @@
 				}
 			});
 			$.each(o.formids.split(','), function(i, f) {
-				$(self.escId(f)).bind("submit", function(e) { 
-					e.preventDefault(); 
+				$(self.escId(f)).bind("submit", function(e) {
+					e.preventDefault();
 				});
 			});
 			$elem.click( function() {
@@ -960,17 +963,17 @@
 			$elem.click( function(e) {
 				var form = $(self.escId(o.formids)),
 					orginal = {};
-				orginal.formvalidate = true; 
-				e.preventDefault(); 
+				orginal.formvalidate = true;
+				e.preventDefault();
 				if (o.validate) {
 					orginal.formvalidate = self.validateForm(form, o);
 					if (o.onaftervalidation) {
-						$.each(o.onaftervalidation.split(','), function(i, topic) { 
+						$.each(o.onaftervalidation.split(','), function(i, topic) {
 							$elem.publish(topic, $elem, orginal);
 						});
-					}  
+					}
 				}
-				
+
 				if(orginal.formvalidate) {
                     if ( o.href && o.href != "#") {
                         form[0].action = o.href;
@@ -985,11 +988,11 @@
 				$elem.subscribe(o.listentopics, function(event) {
 					var form = $(self.escId(event.data.formids)),
 						orginal = {formvalidate : true};
-					
+
 					if (event.data.validate) {
 						orginal.formvalidate = self.validateForm(form, o);
 						if (o.onaftervalidation) {
-							$.each(o.onaftervalidation.split(','), function(i, topic) { 
+							$.each(o.onaftervalidation.split(','), function(i, topic) {
 								$elem.publish(topic, $elem, orginal);
 							});
 						}
@@ -1022,7 +1025,7 @@
 			indi, always,
 			modus = 'html',
 			params = {};
-			
+
 		if (data) {
 			$.extend(o, data);
 		}
@@ -1032,7 +1035,7 @@
 		s2j.lasttopic = o.actionTopic;
 		indi = o.indicatorid;
 		always = o.onalw;
-		
+
 		isDisabled = o.disabled === null ? isDisabled : o.disabled;
 		isDisabled = container.prop('disabled');
 		if (event.originalEvent) { // means that container load is being triggered by other action (link button/link click) need to see if that button/link is disabled
@@ -1227,12 +1230,12 @@
 
 			if (o.validate && orginal.options.submit)  {
 				orginal.options.submit = s2j.validateForm(form, o);
-				orginal.formvalidate = orginal.options.submit; 
+				orginal.formvalidate = orginal.options.submit;
 				if (o.onaftervalidation) {
-					$.each(o.onaftervalidation.split(','), function(i, topic) { 
+					$.each(o.onaftervalidation.split(','), function(i, topic) {
 						elem.publish(topic, elem, orginal);
 					});
-				}  
+				}
 			}
 			if (orginal.options.submit) {
 				s2j.showIndicator(indi);

--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
@@ -991,6 +991,7 @@
                         });
                     };
                 }
+<<<<<<< Upstream, based on origin/release/4.0.3
                  else {
                     params.source = function(request, response) {
                         $.ajax({
@@ -1014,6 +1015,21 @@
                             dataType : 'json'
                         });
                     }
+=======
+                else {
+                    params.source = function (request, response) {
+                        self.abortReq(o.id);
+                        self.currentXhr[o.id] = $.ajax({
+                            url: self.addForms(o.formids, url),
+                            dataType: "json",
+                            type: o.requesttype,
+                            data: {
+                                term: request.term
+                            },
+                            success: response
+                        });
+                    };
+>>>>>>> bb894ed added requestType functionality to sj:autocompleter
                 }
             }
             else if (o.list && o.selectBox === false) {

--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
@@ -997,7 +997,7 @@
                 	params.source = function( request, response ) {
                         $.ajax({
                             url: self.addForms(o.formids, url),
-                            data: { query: request.term},
+                            data: request,
                             success: function(data){
                                 response(data);
                             },

--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
@@ -867,7 +867,7 @@
             //Fixes #46 add custom/error classes to widget
             cssClasses = $(self.escId(o.hiddenid)).attr('class');
             if (typeof cssClasses !== 'undefined' && cssClasses !== ""){
-            	$elem.attr('class',cssClasses);
+                $elem.attr('class',cssClasses);
             }
             if (o.href && o.href !== '#') {
                 url = o.href;

--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
@@ -866,7 +866,7 @@
             }      
             //Fixes #46 add custom/error classes to widget
             cssClasses = $(self.escId(o.hiddenid)).attr('class');
-            if (typeof cssClasses != 'undefined' && cssClasses != ""){
+            if (typeof cssClasses !== 'undefined' && cssClasses !== ""){
             	$elem.attr('class',cssClasses);
             }
             if (o.href && o.href !== '#') {
@@ -992,9 +992,13 @@
                     };
                 }
 <<<<<<< Upstream, based on origin/release/4.0.3
+<<<<<<< Upstream, based on origin/release/4.0.3
+=======
+>>>>>>> a0b6e2b #138 - removing commented old code. corrected indentation
                  else {
                     params.source = function(request, response) {
                         $.ajax({
+<<<<<<< Upstream, based on origin/release/4.0.3
 <<<<<<< Upstream, based on origin/release/4.0.3
                             url : self.addForms(o.formids, url),
                             data : request,
@@ -1004,6 +1008,11 @@
                             data: request,
                             success: function(data){
 >>>>>>> 3f7e3ca refs #36
+=======
+                            url : self.addForms(o.formids, url),
+                            data : request,
+                            success : function(data) {
+>>>>>>> a0b6e2b #138 - removing commented old code. corrected indentation
                                 response(data);
                             },
                             error : function(jqXHR, textStatus, errorThrown) {
@@ -1021,6 +1030,7 @@
                             dataType : 'json'
                         });
                     }
+<<<<<<< Upstream, based on origin/release/4.0.3
 =======
                 else {
                     params.source = function (request, response) {
@@ -1036,6 +1046,8 @@
                         });
                     };
 >>>>>>> bb894ed added requestType functionality to sj:autocompleter
+=======
+>>>>>>> a0b6e2b #138 - removing commented old code. corrected indentation
                 }
             }
             else if (o.list && o.selectBox === false) {

--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
@@ -867,7 +867,7 @@
             //Fixes #46 add custom/error classes to widget
             cssClasses = $(self.escId(o.hiddenid)).attr('class');
             if (typeof cssClasses !== 'undefined' && cssClasses !== ""){
-            	$elem.attr('class',cssClasses);
+                $elem.attr('class',cssClasses);
             }
             if (o.href && o.href !== '#') {
                 url = o.href;
@@ -918,16 +918,15 @@
                                 self.hideIndicator(o.indicatorid);
                             },
                             error: function(jqXHR, textStatus, errorThrown){
-    							if (o.onerr) {
-    								$.each(o.onerr.split(','), function(i, etopic) {
-    									var orginal = {};
-    									orginal.request = jqXHR;
-    									orginal.status = textStatus;
-    									orginal.error = errorThrown;
-    									self.publishTopic($elem, etopic, orginal);
-    								});
-
-    							}
+                                if (o.onerr) {
+                                    $.each(o.onerr.split(','), function(i, etopic) {
+                                        var orginal = {};
+                                        orginal.request = jqXHR;
+                                        orginal.status = textStatus;
+                                        orginal.error = errorThrown;
+                                        self.publishTopic($elem, etopic, orginal);
+                                    });
+                                }
                             },
                             success: function (data) {
                                 self.currentXhr[o.id] = null;

--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
@@ -917,6 +917,18 @@
                             complete: function (request, status) {
                                 self.hideIndicator(o.indicatorid);
                             },
+                            error: function(jqXHR, textStatus, errorThrown){
+    							if (o.onerr) {
+    								$.each(o.onerr.split(','), function(i, etopic) {
+    									var orginal = {};
+    									orginal.request = jqXHR;
+    									orginal.status = textStatus;
+    									orginal.error = errorThrown;
+    									self.publishTopic($elem, etopic, orginal);
+    								});
+
+    							}
+                            },
                             success: function (data) {
                                 self.currentXhr[o.id] = null;
                                 var x = 0,
@@ -981,7 +993,29 @@
                     };
                 }
                 else {
-                    params.source = self.addForms(o.formids, url);
+                   // params.source = self.addForms(o.formids, url);
+                	params.source = function( request, response ) {
+                        $.ajax({
+                            url: self.addForms(o.formids, url),
+                            data: { query: request.term},
+                            success: function(data){
+                                response(data);
+                            },
+                            error: function(jqXHR, textStatus, errorThrown){
+                            	if (o.onerr) {
+    								$.each(o.onerr.split(','), function(i, etopic) {
+    									var orginal = {};
+    									orginal.request = jqXHR;
+    									orginal.status = textStatus;
+    									orginal.error = errorThrown;
+    									self.publishTopic($elem, etopic, orginal);
+    								});
+
+    							}
+                            },
+                          dataType: 'json'
+                        });
+                	}
                 }
             }
             else if (o.list && o.selectBox === false) {

--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
@@ -850,7 +850,8 @@
         autocompleter: function ($elem, o) {
             var self = this,
                 params = {},
-                url = '';
+                url = '',
+                cssClasses;
             self.log('init autocompleter with id: ' + o.id);
             if (!self.loadAtOnce) {
                 self.require([
@@ -862,6 +863,11 @@
                     "js/base/unique-id" + self.minSuffix + ".js",
                     "js/base/autocomplete" + self.minSuffix + ".js"
                 ]);
+            }
+            //Fixes #46 add custom/error classes to widget
+            cssClasses = $(self.escId(o.hiddenid)).attr('class');
+            if (typeof cssClasses != 'undefined' && cssClasses != ""){
+            	$elem.attr('class',cssClasses);
             }
             if (o.href && o.href !== '#') {
                 url = o.href;

--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
@@ -863,16 +863,11 @@
                     "js/base/unique-id" + self.minSuffix + ".js",
                     "js/base/autocomplete" + self.minSuffix + ".js"
                 ]);
-            }
+            }      
             //Fixes #46 add custom/error classes to widget
             cssClasses = $(self.escId(o.hiddenid)).attr('class');
-<<<<<<< Upstream, based on origin/release/4.0.3
-            if (typeof cssClasses !== 'undefined' && cssClasses !== ""){
-                $elem.attr('class',cssClasses);
-=======
             if (typeof cssClasses != 'undefined' && cssClasses != ""){
             	$elem.attr('class',cssClasses);
->>>>>>> 8c708c0 Fixes #46 
             }
             if (o.href && o.href !== '#') {
                 url = o.href;

--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
@@ -866,7 +866,7 @@
             }
             //Fixes #46 add custom/error classes to widget
             cssClasses = $(self.escId(o.hiddenid)).attr('class');
-            if (typeof cssClasses != 'undefined' && cssClasses != ""){
+            if (typeof cssClasses !== 'undefined' && cssClasses !== ""){
             	$elem.attr('class',cssClasses);
             }
             if (o.href && o.href !== '#') {
@@ -992,30 +992,29 @@
                         });
                     };
                 }
-                else {
-                   // params.source = self.addForms(o.formids, url);
-                	params.source = function( request, response ) {
+                 else {
+                    params.source = function(request, response) {
                         $.ajax({
-                            url: self.addForms(o.formids, url),
-                            data: request,
-                            success: function(data){
+                            url : self.addForms(o.formids, url),
+                            data : request,
+                            success : function(data) {
                                 response(data);
                             },
-                            error: function(jqXHR, textStatus, errorThrown){
-                            	if (o.onerr) {
-    								$.each(o.onerr.split(','), function(i, etopic) {
-    									var orginal = {};
-    									orginal.request = jqXHR;
-    									orginal.status = textStatus;
-    									orginal.error = errorThrown;
-    									self.publishTopic($elem, etopic, orginal);
-    								});
-
-    							}
+                            error : function(jqXHR, textStatus, errorThrown) {
+                                if (o.onerr) {
+                                    $.each(o.onerr.split(','), function(i, etopic) {
+                                        var orginal = {};
+                                        orginal.request = jqXHR;
+                                        orginal.status = textStatus;
+                                        orginal.error = errorThrown;
+                                        self.publishTopic($elem, etopic,
+                                                orginal);
+                                    });
+                                }
                             },
-                          dataType: 'json'
+                            dataType : 'json'
                         });
-                	}
+                    }
                 }
             }
             else if (o.list && o.selectBox === false) {

--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
@@ -866,8 +866,13 @@
             }
             //Fixes #46 add custom/error classes to widget
             cssClasses = $(self.escId(o.hiddenid)).attr('class');
+<<<<<<< Upstream, based on origin/release/4.0.3
             if (typeof cssClasses !== 'undefined' && cssClasses !== ""){
                 $elem.attr('class',cssClasses);
+=======
+            if (typeof cssClasses != 'undefined' && cssClasses != ""){
+            	$elem.attr('class',cssClasses);
+>>>>>>> 8c708c0 Fixes #46 
             }
             if (o.href && o.href !== '#') {
                 url = o.href;

--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
@@ -995,9 +995,15 @@
                  else {
                     params.source = function(request, response) {
                         $.ajax({
+<<<<<<< Upstream, based on origin/release/4.0.3
                             url : self.addForms(o.formids, url),
                             data : request,
                             success : function(data) {
+=======
+                            url: self.addForms(o.formids, url),
+                            data: request,
+                            success: function(data){
+>>>>>>> 3f7e3ca refs #36
                                 response(data);
                             },
                             error : function(jqXHR, textStatus, errorThrown) {

--- a/struts2-jquery-richtext-plugin/pom.xml
+++ b/struts2-jquery-richtext-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     <artifactId>struts2-jquery-richtext-plugin</artifactId>
     <name>Struts 2 jQuery Richtext Plugin</name>

--- a/struts2-jquery-showcase/pom.xml
+++ b/struts2-jquery-showcase/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     <artifactId>struts2-jquery-showcase</artifactId>
     <name>Struts 2 jQuery Showcase</name>

--- a/struts2-jquery-showcase/pom.xml
+++ b/struts2-jquery-showcase/pom.xml
@@ -15,7 +15,7 @@
     </scm>
 
     <properties>
-        <log4j2.version>2.7</log4j2.version>
+        <log4j2.version>2.9.0</log4j2.version>
     </properties>
 
     <dependencies>

--- a/struts2-jquery-tree-plugin/pom.xml
+++ b/struts2-jquery-tree-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.jgeppert.struts2.jquery</groupId>
         <artifactId>struts2-jquery</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
     <artifactId>struts2-jquery-tree-plugin</artifactId>
     <name>Struts 2 jQuery Tree Plugin</name>


### PR DESCRIPTION
- css/error/class declared in autocompleter tag taken into account by
generated html widget
- removed duplicated ```html <input type="hidden" />``` declaration in
autocompleter.ftl
- add support for onErrorTopics