### PR TITLE
Fix IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ hs_err_pid*
 # IntelliJ
 /.idea/
 
+# jenv
+.java-version

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
 	<properties>
 		<currentVersion>${project.version}</currentVersion>
-		<struts2.version>2.5.14.1</struts2.version>
+		<struts2.version>2.5.26</struts2.version>
 		<jetty.plugin.version>9.4.8.v20171121</jetty.plugin.version>
 		<tlib.version>2.3</tlib.version>
 		<minify.version>1.7.4</minify.version>

--- a/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/components/AbstractFormElement.java
+++ b/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/components/AbstractFormElement.java
@@ -56,7 +56,7 @@ public abstract class AbstractFormElement extends AbstractContainer {
         }
 
         if (ancestor != null && StringUtils.isBlank(formIds)) {
-            addParameter(PARAM_FORM_IDS, ((Form) ancestor).getId());
+            addParameter(PARAM_FORM_IDS, ancestor.getParameters().get("id"));
         }
     }
 

--- a/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/components/Submit.java
+++ b/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/components/Submit.java
@@ -220,7 +220,7 @@ public class Submit extends AbstractRemoteBean implements ButtonBean {
         }
 
         if (form != null && StringUtils.isBlank(formIds)) {
-            addParameter(PARAM_FORM_IDS, form.getId());
+            addParameter(PARAM_FORM_IDS, form.getParameters().get("id"));
         }
     }
 


### PR DESCRIPTION
This PR tries to fix ID generated by the framework. As from Struts 2.5.26, the `id` isn't evaluated once set, the evaluation was postponed till calling `evaluateExtraParams()`.

Fixes [WW-5107](https://issues.apache.org/jira/browse/WW-5107)