### PR TITLE
Use already generated id

### DIFF
--- a/struts2-jquery-grid-plugin/src/main/java/com/jgeppert/struts2/jquery/grid/components/GridColumn.java
+++ b/struts2-jquery-grid-plugin/src/main/java/com/jgeppert/struts2/jquery/grid/components/GridColumn.java
@@ -151,7 +151,7 @@ public class GridColumn extends AbstractRemoteBean {
 
         Component grid = findAncestor(Grid.class);
         if (grid != null) {
-            addParameter(PARAM_GRID, ((Grid) grid).getId());
+            addParameter(PARAM_GRID, grid.getParameters().get("id"));
         }
     }
 


### PR DESCRIPTION
Fixes using `%{...}` for grid id