### PR TITLE
Bump derby from 10.11.1.1 to 10.14.2.0 in /struts2-jquery-grid-showcase

### DIFF
--- a/struts2-jquery-grid-showcase/pom.xml
+++ b/struts2-jquery-grid-showcase/pom.xml
@@ -24,7 +24,7 @@
 		<javassist.version>3.17.1-GA</javassist.version>
 		<velocity.version>1.7</velocity.version>
 		<velocity-tools.version>2.0</velocity-tools.version>
-		<derby.version>10.11.1.1</derby.version>
+		<derby.version>10.14.2.0</derby.version>
 		<c3p0.version>0.9.5.5</c3p0.version>
 		<hibernate-validator.version>4.3.2.Final</hibernate-validator.version>
 		<javax.interceptor-api.version>1.2</javax.interceptor-api.version>


### PR DESCRIPTION
Bumps derby from 10.11.1.1 to 10.14.2.0.

---
updated-dependencies:
- dependency-name: org.apache.derby:derby
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

closes #242 