### PR TITLE
Disables Auto-Escape for the Dialog

### DIFF
--- a/struts2-jquery-plugin/src/main/resources/template/jquery/dialog-close.ftl
+++ b/struts2-jquery-plugin/src/main/resources/template/jquery/dialog-close.ftl
@@ -73,7 +73,7 @@ jQuery(document).ready(function () {
     options_${escapedOptionId}.appendTo = "${parameters.appendTo}";
   </#if>
   <#if parameters.buttons?if_exists != "">
-	options_${escapedOptionId}.buttons = ${parameters.buttons?string};
+	options_${escapedOptionId}.buttons = ${parameters.buttons?no_esc};
   </#if>
   <#if parameters.draggable?exists>
 	options_${escapedOptionId}.draggable = ${parameters.draggable?string};


### PR DESCRIPTION
Since Commit c25b158 the buttons-Options are Auto-Escaped, so the ' turns to "&#39;". This Commit disables the Auto-Escape (see https://freemarker.apache.org/docs/dgui_misc_autoescaping.html#dgui_misc_autoescaping_disableautoesc) for the Dialog.
You can see the Effect in the Dialog-Part in the Showcase.