### PR TITLE
remove deprecated distance and delay options from selectable

### DIFF
--- a/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/components/AbstractContainer.java
+++ b/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/components/AbstractContainer.java
@@ -141,9 +141,7 @@ public abstract class AbstractContainer extends AbstractRemoteBean implements Re
     protected String selectable;
     protected String selectableAutoRefresh;
     protected String selectableCancel;
-    protected String selectableDelay;
     protected String selectableFilter;
-    protected String selectableDistance;
     protected String selectableTolerance;
 
     protected String selectableOnUnselectedTopics;
@@ -462,14 +460,6 @@ public abstract class AbstractContainer extends AbstractRemoteBean implements Re
             addParameter(PARAM_SELECTABLE, Boolean.TRUE);
             StringBuilder selectableBuilder = new StringBuilder();
             selectableBuilder.append("{");
-            if (selectableDelay != null) {
-                selectableBuilder.append(", delay: ");
-                selectableBuilder.append(findString(selectableDelay));
-            }
-            if (selectableDistance != null) {
-                selectableBuilder.append(", distance: ");
-                selectableBuilder.append(findString(selectableDistance));
-            }
             if (selectableFilter != null) {
                 selectableBuilder.append(", filter: '");
                 selectableBuilder.append(findString(selectableFilter));
@@ -928,16 +918,6 @@ public abstract class AbstractContainer extends AbstractRemoteBean implements Re
     @StrutsTagAttribute(description = "Prevents selecting if you start on elements matching the selector. Default: ':input,option'")
     public void setSelectableCancel(String selectableCancel) {
         this.selectableCancel = selectableCancel;
-    }
-
-    @StrutsTagAttribute(description = "Time in milliseconds to define when the selecting should start. It helps preventing unwanted selections when clicking on an element.")
-    public void setSelectableDelay(String selectableDelay) {
-        this.selectableDelay = selectableDelay;
-    }
-
-    @StrutsTagAttribute(description = "Tolerance, in pixels, for when selecting should start. If specified, selecting will not start until after mouse is dragged beyond distance.")
-    public void setSelectableDistance(String selectableDistance) {
-        this.selectableDistance = selectableDistance;
     }
 
     @StrutsTagAttribute(description = "The matching child elements will be made selectees (able to be selected). Default: '*'")

--- a/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/components/SelectableBean.java
+++ b/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/components/SelectableBean.java
@@ -30,10 +30,6 @@ public interface SelectableBean {
 
     void setSelectableCancel(String selectableCancel);
 
-    void setSelectableDelay(String selectableDelay);
-
-    void setSelectableDistance(String selectableDistance);
-
     void setSelectableFilter(String selectableFilter);
 
     void setSelectableTolerance(String selectableTolerance);

--- a/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/views/jsp/ui/AbstractContainerTag.java
+++ b/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/views/jsp/ui/AbstractContainerTag.java
@@ -97,13 +97,11 @@ public abstract class AbstractContainerTag extends AbstractRemoteTag implements 
     protected String selectable;
     protected String selectableAutoRefresh;
     protected String selectableCancel;
-    protected String selectableDelay;
     protected String selectableFilter;
     protected String selectableOnSelectedTopics;
     protected String selectableOnSelectingTopics;
     protected String selectableOnStartTopics;
     protected String selectableOnStopTopics;
-    protected String selectableDistance;
     protected String selectableTolerance;
     protected String selectableOnUnselectedTopics;
     protected String selectableOnUnselectingTopics;
@@ -218,8 +216,6 @@ public abstract class AbstractContainerTag extends AbstractRemoteTag implements 
         container.setSelectable(selectable);
         container.setSelectableAutoRefresh(selectableAutoRefresh);
         container.setSelectableCancel(selectableCancel);
-        container.setSelectableDelay(selectableDelay);
-        container.setSelectableDistance(selectableDistance);
         container.setSelectableFilter(selectableFilter);
         container.setSelectableTolerance(selectableTolerance);
         container.setSelectableOnSelectedTopics(selectableOnSelectedTopics);
@@ -497,14 +493,6 @@ public abstract class AbstractContainerTag extends AbstractRemoteTag implements 
 
     public void setSelectableCancel(String selectableCancel) {
         this.selectableCancel = selectableCancel;
-    }
-
-    public void setSelectableDelay(String selectableDelay) {
-        this.selectableDelay = selectableDelay;
-    }
-
-    public void setSelectableDistance(String selectableDistance) {
-        this.selectableDistance = selectableDistance;
     }
 
     public void setSelectableFilter(String selectableFilter) {

--- a/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/views/jsp/ui/SelectableTag.java
+++ b/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/views/jsp/ui/SelectableTag.java
@@ -31,10 +31,6 @@ public interface SelectableTag {
 
     void setSelectableCancel(String selectableCancel);
 
-    void setSelectableDelay(String selectableDelay);
-
-    void setSelectableDistance(String selectableDistance);
-
     void setSelectableFilter(String selectableFilter);
 
     void setSelectableTolerance(String selectableTolerance);

--- a/struts2-jquery-plugin/src/test/java/com/jgeppert/struts2/jquery/components/AbstractContainerTest.java
+++ b/struts2-jquery-plugin/src/test/java/com/jgeppert/struts2/jquery/components/AbstractContainerTest.java
@@ -106,8 +106,6 @@ class AbstractContainerTest extends AbstractComponentBaseTest {
             // end draggable
             // start selectable
             abstractContainer.setSelectable("true");
-            abstractContainer.setSelectableDelay("150");
-            abstractContainer.setSelectableDistance("30");
             abstractContainer.setSelectableFilter("li");
             abstractContainer.setSelectableCancel("a,.cancel");
             abstractContainer.setSelectableTolerance("fit");
@@ -188,7 +186,7 @@ class AbstractContainerTest extends AbstractComponentBaseTest {
                     .containsEntry("draggableOnStopTopics", "theDraggableOnStopTopic")
                     .containsEntry("selectable", true)
                     .containsEntry("selectableOptions",
-                            "{ delay: 150, distance: 30, filter: 'li' , cancel: 'a,.cancel' , tolerance: 'fit'  }")
+                            "{ filter: 'li' , cancel: 'a,.cancel' , tolerance: 'fit'  }")
                     .containsEntry("selectableOnSelectedTopics", "theSelectableOnSelectTopic")
                     .containsEntry("selectableOnSelectingTopics", "theSelectableOnSelectingTopic")
                     .containsEntry("selectableOnStopTopics", "theSelectableOnStopTopic")


### PR DESCRIPTION
closes #279 