### PR TITLE
Fixes #313 - tabbedpanel is no longer working due to deprecated jqXHR.success

### DIFF
--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.ui.struts2.js
@@ -379,7 +379,7 @@
                         return;
                     }
 
-                    ui.jqXHR.success(function () {
+                    ui.jqXHR.done(function () {
                         ui.tab.data("loaded", true);
                     });
                 }


### PR DESCRIPTION
See the comment added to #313.