### PR TITLE
Add missing tags to tld for overlayColor and overlayOpacity

### DIFF
--- a/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/components/Dialog.java
+++ b/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/components/Dialog.java
@@ -253,6 +253,16 @@ public class Dialog extends AbstractRemoteBean {
     public void setHideEffect(String hideEffect) {
         this.hideEffect = hideEffect;
     }
+    
+    @StrutsTagAttribute(description = "Overlay color when modal is true. e.g. #000")
+    public void setOverlayColor(String overlayColor) {
+        this.overlayColor = overlayColor;
+    }
+
+    @StrutsTagAttribute(description = "Overlay opacity when modal is true. e.g. 0.7")
+    public void setOverlayOpacity(String overlayOpacity) {
+        this.overlayOpacity = overlayOpacity;
+    }
 
     @StrutsTagAttribute(description = "The maximum height to which the dialog can be resized, in pixels.")
     public void setMaxHeight(String maxHeight) {

--- a/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/views/jsp/ui/DialogTag.java
+++ b/struts2-jquery-plugin/src/main/java/com/jgeppert/struts2/jquery/views/jsp/ui/DialogTag.java
@@ -47,6 +47,8 @@ public class DialogTag extends AbstractRemoteTag {
     protected String autoOpen;
     protected String showEffect;
     protected String hideEffect;
+    protected String overlayColor;
+    protected String overlayOpacity;
     protected String onOpenTopics;
     protected String onCloseTopics;
     protected String onFocusTopics;
@@ -146,6 +148,14 @@ public class DialogTag extends AbstractRemoteTag {
 
     public void setHideEffect(String hideEffect) {
         this.hideEffect = hideEffect;
+    }
+    
+    public void setOverlayColor(String overlayColor) {
+        this.overlayColor = overlayColor;
+    }
+
+    public void setOverlayOpacity(String overlayOpacity) {
+        this.overlayOpacity = overlayOpacity;
     }
 
     public void setMaxHeight(String maxHeight) {

--- a/struts2-jquery-plugin/src/site/docs/dialog-attributes.html
+++ b/struts2-jquery-plugin/src/site/docs/dialog-attributes.html
@@ -590,6 +590,22 @@
         <td class="tag-attribute">A comma delimited list of topics to open the dialog.</td>
     </tr>
     <tr>
+        <td class="tag-attribute">overlayColor</td>
+        <td class="tag-attribute">false</td>
+        <td class="tag-attribute"></td>
+        <td class="tag-attribute">false</td>
+        <td class="tag-attribute">String</td>
+        <td class="tag-attribute">Overlay color when modal is true. e.g. #000</td>
+    </tr>
+    <tr>
+        <td class="tag-attribute">overlayOpacity</td>
+        <td class="tag-attribute">false</td>
+        <td class="tag-attribute"></td>
+        <td class="tag-attribute">false</td>
+        <td class="tag-attribute">String</td>
+        <td class="tag-attribute">Overlay opacity when modal is true. e.g. 0.7</td>
+    </tr>
+    <tr>
         <td class="tag-attribute">performClearTagStateForTagPoolingServers</td>
         <td class="tag-attribute">false</td>
         <td class="tag-attribute">false</td>


### PR DESCRIPTION
Adds missing tags  overlayColor, overlayOpacity for tld
```
<sj:dialog 
    	id="mymodaldialog" 
    	href="%{ajax}" 
    	modal="true" 
    	overlayColor="#903" 
    	overlayOpacity="0.8" 
    	title="Modal Dialog"
    	position="{
            my: 'right top',
            at: 'right-200 top+100'
        }"

```
From the showcase application menu it is Widgets | Dialog | Modal Dialog.

