### PR TITLE
Remove cache :true on .requrie(..) javascript method 

### DIFF
--- a/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.struts2.js
+++ b/struts2-jquery-plugin/src/main/resources/template/js/struts2/jquery.struts2.js
@@ -125,7 +125,6 @@
 				url :path + file,
 				success :successFunction,
 				dataType :"script",
-				cache :true,
 				async :false
 				});
 				$.struts2_jquery.scriptCache[file] = true;


### PR DESCRIPTION
To make debugging easier, remove cache :true (the default) on the require method (it includes js resources and stores them in the browser cache).  It overrides any ajaxcache="true/false" tag setting.

As the default on jquery is true is should not have any upstream issues.