### PR TITLE
Uses temurin instead of adopt

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         java-version: 17
-        distribution: adopt
+        distribution: temurin
         cache: maven
         server-id: struts2-jquery.snapshots
         server-username: MAVEN_USERNAME


### PR DESCRIPTION
NOTE: AdoptOpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt and adopt-openj9, to temurin and semeru respectively, to keep receiving software and security updates. See more details in the Good-bye AdoptOpenJDK post.