### PR TITLE
Use maven.compiler.release to support Java 8 target version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,10 +32,10 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - name: Set up JDK 17
+    - name: Set up Java
       uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: 21
         distribution: temurin
         cache: maven
         server-id: struts2-jquery.snapshots

--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,9 @@
 
 	<properties>
 		<currentVersion>${project.version}</currentVersion>
-		<java.version>17</java.version>
+		<java.version>8</java.version>
+		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
 		<!-- plugin versions -->
 		<jetty.plugin.version>9.4.56.v20240826</jetty.plugin.version>
 		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
@@ -164,8 +163,6 @@
 					<version>${maven-compiler-plugin.version}</version>
 					<configuration>
 						<forceJavacCompilerUse>true</forceJavacCompilerUse>
-						<source>${java.version}</source>
-						<target>${java.version}</target>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
This replaces maven.compiler.source and maven.compiler.target

https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html#option-release

>Note: When using --release, you cannot also use the --source/-source or --target/-target options.

https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#release