### PR TITLE
Attach sources when deploying or preparing a release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,16 +132,16 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<artifactId>maven-release-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<artifactId>maven-deploy-plugin</artifactId>
-			</plugin>
-			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<artifactId>maven-release-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<artifactId>maven-deploy-plugin</artifactId>
 			</plugin>
 		</plugins>
 
@@ -189,6 +189,14 @@
 					<!-- Attach source jar to builds -->
 					<artifactId>maven-source-plugin</artifactId>
 					<version>${maven-source-plugin.version}</version>
+					<executions>
+						<execution>
+							<id>attach-sources</id>
+							<goals>
+								<goal>jar-no-fork</goal>
+							</goals>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<groupId>com.samaxes.maven</groupId>
@@ -208,11 +216,10 @@
 					<artifactId>maven-release-plugin</artifactId>
 					<version>${maven-release-plugin.version}</version>
 					<configuration>
-						<arguments>-Prelease ${arguments}</arguments>
+						<releaseProfiles>release</releaseProfiles>
 						<autoVersionSubmodules>true</autoVersionSubmodules>
 						<goals>deploy</goals>
 						<tagNameFormat>@{project.version}</tagNameFormat>
-						<useReleaseProfile>false</useReleaseProfile>
 					</configuration>
 				</plugin>
 			</plugins>
@@ -222,11 +229,6 @@
 	<profiles>
 		<profile>
 			<id>release</id>
-			<activation>
-				<property>
-					<name>release</name>
-				</property>
-			</activation>
 			<build>
 				<defaultGoal>deploy</defaultGoal>
 				<plugins>


### PR DESCRIPTION
**NOTE**: this fix didn't help (at least when testing locally)

Each time I'm trying to prepare a new release I must manually create and deploy source by checking out a tag and then running `mvn source:jar deploy -Prelease` again.

Even with this fix, running `mvn deploy` doesn't produce a jar file with source code locally.

Any help? cc: @sepe81 @sdutry