### PR TITLE
test: fix SelectTagIT async-loaded options race

### DIFF
--- a/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/select/SelectTagIT.java
+++ b/struts2-jquery-integration-tests/src/test/java/com/jgeppert/jquery/select/SelectTagIT.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.List;
 
@@ -24,6 +25,10 @@ public class SelectTagIT extends AbstractJQueryTest {
         waitForInitialPageLoad();
 
         WebElement selectElement = driver.findElement(By.id("myselect"));
+        // The sj:select loads its options asynchronously via AJAX (href); the server-side
+        // markup only contains the empty placeholder option. Wait for the options to load
+        // before asserting, otherwise we race the AJAX population.
+        wait.until(ExpectedConditions.numberOfElementsToBe(By.cssSelector("#myselect option"), 26));
         List<WebElement> options = selectElement.findElements(By.tagName("option"));
 
         assertEquals("letter", selectElement.getAttribute("name"));
@@ -42,6 +47,10 @@ public class SelectTagIT extends AbstractJQueryTest {
         waitForInitialPageLoad();
 
         WebElement selectElement = driver.findElement(By.id("myselect"));
+        // The sj:select loads its options asynchronously via AJAX (href); the server-side
+        // markup only contains the empty placeholder option. Wait for the options to load
+        // before asserting, otherwise we race the AJAX population.
+        wait.until(ExpectedConditions.numberOfElementsToBe(By.cssSelector("#myselect option"), 26));
         List<WebElement> options = selectElement.findElements(By.tagName("option"));
 
         assertEquals("letter", selectElement.getAttribute("name"));
@@ -60,6 +69,10 @@ public class SelectTagIT extends AbstractJQueryTest {
         waitForInitialPageLoad();
 
         WebElement selectElement = driver.findElement(By.id("myselect"));
+        // The sj:select loads its options asynchronously via AJAX (href); the server-side
+        // markup only contains the empty placeholder option. Wait for the options to load
+        // before asserting, otherwise we race the AJAX population.
+        wait.until(ExpectedConditions.numberOfElementsToBe(By.cssSelector("#myselect option"), 26));
         List<WebElement> options = selectElement.findElements(By.tagName("option"));
 
         assertEquals("letter", selectElement.getAttribute("name"));


### PR DESCRIPTION
## Problem

`SelectTagIT` (all 12 cases) fails under HtmlUnit with `expected: <26> but was: <1>`. It passes in CI because CI runs ChromeDriver.

## Root cause

`<sj:select>` configured with an `href` (here `/ajax/lettersinobject`) renders only the empty placeholder `<option value=""></option>` server-side and loads its real options **asynchronously via AJAX** (wired in the element's `jQuery(document).ready(...)`). The tests read the options immediately after `waitForInitialPageLoad()`, which returns before that async population finishes — so they see the lone placeholder (1 option).

This is the **same async-load race** addressed for the widgets in #921, not a separate rendering bug. Confirmed by instrumentation: in HtmlUnit the option count reaches 26 within ~105ms of `waitForInitialPageLoad()` returning (1ms for `loadatonce`). HtmlUnit loses the race deterministically because the in-process driver reads faster than the AJAX completes; Chrome happened to win it, which is why CI was green.

## Fix (test-only)

Wait for the options to load before asserting, mirroring the content-wait used for auto-loading content in #921:

```java
wait.until(ExpectedConditions.numberOfElementsToBe(By.cssSelector("#myselect option"), 26));
```

Applied to all three methods (`testStringlistData`, `testMapData`, `testObjectListData`).

## Verification

- `SelectTagIT` green across repeated HtmlUnit runs.
- **Full integration suite green under HtmlUnit: 168 tests, 0 failures, 0 errors** (4 tag-gated TreeTagIT skips). This was the last remaining red class after #921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
