### PR TITLE
ci: prevent CI from deploying release versions unsigned

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -122,5 +122,11 @@ jobs:
     - name: Deploy SNAPSHOT
       if: github.ref == 'refs/heads/release/5.0.x' || github.ref == 'refs/heads/release/6.0.x'
       run: |
+        VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)
+        if [[ "$VERSION" != *-SNAPSHOT ]]; then
+          echo "⏭️  Version $VERSION is not a SNAPSHOT (release-plugin commit) — skipping deploy"
+          exit 0
+        fi
+        echo "🚀 Deploying $VERSION"
         echo "${{ secrets.MAVEN_SETTINGS }}" > ~/.m2/settings-central.xml
         mvn -B -DskipTests=true deploy -s ~/.m2/settings-central.xml

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
 		<profile>
 			<id>release</id>
             <properties>
-                <name>skipITs</name>
+                <skipITs>true</skipITs>
             </properties>
 			<build>
 				<defaultGoal>deploy</defaultGoal>

--- a/struts2-jquery-integration-tests/pom.xml
+++ b/struts2-jquery-integration-tests/pom.xml
@@ -208,6 +208,13 @@
                         <skip>true</skip>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <configuration>
+                        <skipPublishing>true</skipPublishing>
+                    </configuration>
+                </plugin>
             </plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
## Problem

Publishing `6.1.0` to the Central Portal failed with `Missing signature for file` for every artifact.

Root cause: the **Deploy SNAPSHOT** job runs `mvn deploy` without `-Prelease` (no GPG signing) and without `-DskipITs` (includes `integration-tests`) on every push to `release/6.0.x`. When `mvn release:prepare` pushes its `[maven-release-plugin] prepare release 6.1.0` commit, the POM version is briefly the *release* version `6.1.0`, so CI uploaded an **unsigned** `6.1.0` bundle to the Portal ([run 28433641195](https://github.com/struts-community-plugins/struts2-jquery/actions/runs/28433641195)). That unsigned deployment — not the signed one from `release:perform` — is what failed validation.

## Fix

- **maven.yml**: the deploy step now reads `project.version` and skips unless it ends in `-SNAPSHOT`, so a release-plugin commit can never trigger a release deploy.
- **pom.xml**: fix `<name>skipITs</name>` typo → `<skipITs>true</skipITs>` so the `release` profile actually excludes `integration-tests`.
- **integration-tests/pom.xml**: add `<skipPublishing>true</skipPublishing>` to `central-publishing-maven-plugin` — the existing `maven-deploy-plugin` `<skip>` is ignored because `central-publishing` (extensions=true) replaces the deploy goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)