### PR TITLE
docs: document WebJars support available since Struts 7.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,66 @@ To access SNAPSHOT builds, you need to declare the snapshot repository lookup in
 </repositories>
 ...
 ```
+
+## WebJars
+
+Since **Struts 7.3.0** WebJars are supported by `struts2-core` itself, so any application built on
+`struts2-jquery` `6.x` can serve client-side libraries straight from a WebJar without extra plumbing.
+`org.webjars:webjars-locator-lite` is a transitive dependency of `struts2-core` — nothing else needs to
+be added to the classpath.
+
+Declare the WebJar you want:
+
+```xml
+<dependency>
+    <groupId>org.webjars</groupId>
+    <artifactId>jquery</artifactId>
+    <version>3.7.1</version>
+</dependency>
+```
+
+Its assets are then served below the Struts static content path, under `/webjars/**`. Both the
+version-less and the versioned form resolve to the same resource:
+
+```
+/<context>/static/webjars/jquery/jquery.min.js
+/<context>/static/webjars/jquery/3.7.1/jquery.min.js
+```
+
+Rather than hardcoding the URL, use the `<s:webjar>` tag from the Struts tag library. It takes a
+version-less path and renders the full, versioned URL including the context path:
+
+```jsp
+<%@ taglib prefix="s" uri="/struts-tags" %>
+
+<script src="<s:webjar path='jquery/jquery.min.js'/>"></script>
+```
+
+renders
+
+```html
+<script src="/myapp/static/webjars/jquery/3.7.1/jquery.min.js"></script>
+```
+
+The tag also accepts `var`, to put the URL on the value stack instead of writing it out:
+
+```jsp
+<s:webjar path="jquery/jquery.min.js" var="jqueryUrl"/>
+```
+
+Two settings control the feature:
+
+| Setting                    | Default | Description                                                       |
+|----------------------------|---------|-------------------------------------------------------------------|
+| `struts.webjars.enabled`   | `true`  | Master switch for resolving and serving WebJar assets              |
+| `struts.webjars.allowlist` | *empty* | Comma-separated list of WebJar names to expose; empty means all    |
+
+In a hardened setup it is worth restricting the allowlist to the WebJars you actually use:
+
+```
+struts.webjars.allowlist=jquery,jquery-ui
+```
+
+Note that the `<sj:head>` tag continues to serve the jQuery and jQuery UI copies bundled inside
+`struts2-jquery-plugin`, and is not affected by these settings. WebJars are the recommended way to add
+*further* client-side libraries to your application.


### PR DESCRIPTION
## Summary

Struts **7.3.0** added WebJars support to `struts2-core` itself (the classes are absent in 7.1.1 and 7.2.1). Since `org.webjars:webjars-locator-lite` is a transitive `compile` dependency of `struts2-core`, any application on `struts2-jquery` 6.x can already serve client-side libraries from a WebJar with no extra setup — this was simply undocumented.

This PR adds a **WebJars** section to `README.md` covering:

- declaring a WebJar dependency
- the `/<context>/static/webjars/**` URLs assets are served under (version-less and versioned both resolve)
- the `<s:webjar>` tag, including its `var` attribute
- the `struts.webjars.enabled` and `struts.webjars.allowlist` settings
- a note that `<sj:head>` continues to serve the jQuery / jQuery UI copies bundled in `struts2-jquery-plugin` and is unaffected by these settings

Documentation only — no code, build or dependency changes.

## Verification

Verified end-to-end against `struts2-jquery-showcase` on Jetty with `org.webjars:jquery:3.7.1` temporarily added (both the dependency and the scratch JSP were reverted afterwards):

```
/static/webjars/jquery/jquery.min.js        200  text/javascript  87533
/static/webjars/jquery/3.7.1/jquery.min.js  200  text/javascript  87533
```

```jsp
<script src="<s:webjar path='jquery/jquery.min.js'/>"></script>
```

rendered

```html
<script src="/struts2-jquery-showcase/static/webjars/jquery/3.7.1/jquery.min.js"></script>
```

## Notes

A full migration of the plugin off its vendored jQuery assets onto WebJars was considered and **not** pursued here: `template/js/base/jquery-ui.js` is generated by `minify-maven-plugin` from the plugin's own split widget sources, the runtime lazy loader resolves paths off `jQuery.scriptPath`, some shipped themes (e.g. `mint-choc`) are not in `org.webjars:jquery-ui-themes`, and `jquery.subscribe` / `jquery.ba-bbq` / `jquery.struts2.js` have no WebJar at all. That would be a separate, breaking change.

🤖 Generated by AI Assistant