### PR TITLE
docs: add 6.1.0 row to the compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Plugin for the popular java web framework struts2 to provide ajax functionalit
 ### versions and compatibility
 | `struts2-jquery` version | `struts2` version               | `Java` version   |
 |--------------------------|---------------------------------|------------------|
+| `6.1.0`                  | version >= `7.2.1`              | version >= `17`  |
 | `6.0.0`                  | version >= `7.0.0`              | version >= `17`  |
 | `5.0.7`                  | version >= `6.7.0`              | version >= `1.8` |
 | `5.0.6`                  | version >= `6.6.0`              | version >= `1.8` |


### PR DESCRIPTION
## Summary

The "versions and compatibility" table in `README.md` stopped at `6.0.0`, even though `6.1.0` has been tagged and released.

Adds the missing row:

| `struts2-jquery` version | `struts2` version | `Java` version |
|---|---|---|
| `6.1.0` | version >= `7.2.1` | version >= `17` |

## Verification

Values taken from the release tag itself rather than from the current branch:

```
$ git show 6.1.0:pom.xml | grep -oE '<struts2.version>[^<]*|<java.version>[^<]*'
<java.version>17
<struts2.version>7.2.1
```

For context, the surrounding tags: `6.0.0`/`6.0.1` → 7.0.0, `6.0.2`/`6.0.3` → 7.1.1, `6.1.0` → 7.2.1. Only `6.1.0` is added here, matching the table's existing habit of listing a subset rather than every patch release.

Documentation only — no code, build or dependency changes.

## Note

The WebJars section added in #950 is gated on Struts **7.3.0**, so it does not apply to `6.1.0` on its minimum Struts version. That section already states the 7.3.0 requirement explicitly, so no change is needed there.

🤖 Generated by AI Assistant